### PR TITLE
Kebab case should validate on single lower-case word

### DIFF
--- a/src/util/selectorValidator.ts
+++ b/src/util/selectorValidator.ts
@@ -6,7 +6,7 @@ export const SelectorValidator = {
     return /^[^\[].+[^\]]$/.test(selector);
   },
   kebabCase(selector: string): boolean {
-    return /^[a-z0-9\-]+\-[a-z0-9\-]+$/.test(selector);
+    return /^[a-z0-9\-]+(\-[a-z0-9\-]+)?$/.test(selector);
   },
   camelCase(selector: string): boolean {
     return /^[a-zA-Z0-9\[\]]+$/.test(selector);

--- a/test/componentSelectorNameRule.spec.ts
+++ b/test/componentSelectorNameRule.spec.ts
@@ -20,30 +20,20 @@ describe('component-selector-name', () => {
         }
       }, 'kebab-case');
     });
-    it('should fail when the selector of component does not contain hyphen character', () => {
-      let source = `
-      @Component({
-        selector: 'foobar'
-      })
-      class Test {}`;
-      assertFailure('component-selector-name', source, {
-        message: 'The selector of the component "Test" should be named kebab-case ($$05-02$$)',
-        startPosition: {
-          line: 2,
-          character: 18
-        },
-        endPosition: {
-          line: 2,
-          character: 26
-        }
-      }, 'kebab-case');
-    });
   });
   describe('valid component selector', () => {
     it('should succeed when set valid selector in @Component', () => {
       let source = `
       @Component({
         selector: 'sg-bar-foo'
+      })
+      class Test {}`;
+      assertSuccess('component-selector-name', source, 'kebab-case');
+    });
+    it('should succeed when selector is single word', () => {
+      let source = `
+      @Component({
+        selector: 'foo'
       })
       class Test {}`;
       assertSuccess('component-selector-name', source, 'kebab-case');


### PR DESCRIPTION
Kebab case is lowercase with words separated-by-dash. Therefore, single
lowercase word is still valid kebab-case.

Moreover, we have separate rules for validating mandatory dash:
- directive-selector-prefix
- component-selector-prefix
- pipe-naming

So for those of us who doesn't want to follow these it should be possible
to use single word selector name with kebab-case rule on.
