### PR TITLE
chore: make typings a normal script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A set of linters for Angular 2 applications, following https:/angular.io/styleguide.",
   "main": "index.js",
   "scripts": {
-    "postinstall": "typings install",
+    "typings": "typings",
     "release": "rimraf dist && tsc && npm t && cp package.json README.md dist/src && ts-node build/links.ts --src ./dist/src",
     "test": "rimraf dist && tsc && mocha --compilers ts:ts-node/register",
     "test:watch": "npm run test -- -w",


### PR DESCRIPTION
You will now need to install typings by hand with: `npm run typings -- install` but now you won't force endusers to have typings installed.