### PR TITLE
feat(rules): add impure pipe rule

### DIFF
--- a/src/pipeImpureRule.ts
+++ b/src/pipeImpureRule.ts
@@ -1,0 +1,61 @@
+import * as Lint from 'tslint/lib/lint';
+import * as ts from 'typescript';
+import {sprintf} from 'sprintf-js';
+import SyntaxKind = require('./util/syntaxKind');
+
+export class Rule extends Lint.Rules.AbstractRule {
+
+    public apply(sourceFile:ts.SourceFile):Lint.RuleFailure[] {
+        return this.applyWithWalker(
+            new ClassMetadataWalker(sourceFile, this));
+    }
+
+    static  FAILURE:string = 'The Pipe decorator of class %s should be pure.';
+}
+
+export class ClassMetadataWalker extends Lint.RuleWalker {
+
+    constructor(sourceFile:ts.SourceFile, private rule:Rule) {
+        super(sourceFile, rule.getOptions());
+    }
+
+    visitClassDeclaration(node:ts.ClassDeclaration) {
+        let className = node.name.text;
+        let decorators = node.decorators || [];
+        decorators.filter(d=> {
+            let baseExpr = <any>d.expression || {};
+            return baseExpr.expression.text === 'Pipe'
+        }).forEach(this.validateProperties.bind(this, className));
+        super.visitClassDeclaration(node);
+    }
+
+    private validateProperties(className:string, pipe:any) {
+        let argument = this.extractArgument(pipe);
+        if (argument.kind === SyntaxKind.current().ObjectLiteralExpression) {
+            argument.properties.filter(n=>n.name.text === 'pure')
+            .forEach(this.validateProperty.bind(this, className))
+        }
+    }
+
+    private extractArgument(pipe:any) {
+        let baseExpr = <any>pipe.expression || {};
+        let args = baseExpr.arguments || [];
+        return args[0];
+    }
+
+    private validateProperty(className:string, property:any) {
+        let propValue:string = property.initializer.getText();
+        if (propValue === "false") {
+            this.addFailure(
+                this.createFailure(
+                    property.getStart(),
+                    property.getWidth(),
+                    sprintf.apply(this, this.createFailureArray(className))));
+        }
+    }
+
+    private createFailureArray(className:string):Array<string> {
+        return [Rule.FAILURE, className];
+    }
+
+}

--- a/src/pipeImpureRule.ts
+++ b/src/pipeImpureRule.ts
@@ -10,7 +10,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             new ClassMetadataWalker(sourceFile, this));
     }
 
-    static  FAILURE:string = 'The Pipe decorator of class %s should be pure.';
+    static  FAILURE:string = 'Warning: impure pipe declared in class %s.';
 }
 
 export class ClassMetadataWalker extends Lint.RuleWalker {

--- a/test/pipeImpureRule.spec.ts
+++ b/test/pipeImpureRule.spec.ts
@@ -9,7 +9,7 @@ describe('pipe-impure', () => {
                       })
                       class Test {}`;
             assertFailure('pipe-impure', source, {
-                message: 'The Pipe decorator of class Test should be pure.',
+                message: 'Warning: impure pipe declared in class Test.',
                 startPosition: {
                     line: 2,
                     character: 24

--- a/test/pipeImpureRule.spec.ts
+++ b/test/pipeImpureRule.spec.ts
@@ -1,0 +1,44 @@
+import {assertFailure, assertSuccess} from './testHelper';
+
+describe('pipe-impure', () => {
+    describe('impure pipe', () => {
+        it('should fail when Pipe is impure', () => {
+            let source = `
+                      @Pipe({
+                        pure: false
+                      })
+                      class Test {}`;
+            assertFailure('pipe-impure', source, {
+                message: 'The Pipe decorator of class Test should be pure.',
+                startPosition: {
+                    line: 2,
+                    character: 24
+                },
+                endPosition: {
+                    line: 2,
+                    character: 35
+                }
+            });
+        });
+    });
+    describe('pure pipe', () => {
+        it('should succeed when Pipe is pure', () => {
+            let source = `
+                    @Pipe({
+                      pure: true
+                    })
+                    class Test {}`;
+            assertSuccess('pipe-impure', source);
+        });
+    });
+    describe('default pipe', () => {
+        it('should succeed when Pipe pure property is not set', () => {
+            let source = `
+                    @Pipe({
+                      name: 'testPipe'
+                    })
+                    class Test {}`;
+            assertSuccess('pipe-impure', source);
+        });
+    });
+});


### PR DESCRIPTION
Added a simple rule for checking impure pipes (the rule was derived from source of the pipe-naming rule).