### PR TITLE
Upgrade dependencies and relax peer dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "minimalist": "1.0.0",
     "mocha": "3.0.2",
     "rimraf": "^2.5.2",
-    "ts-node": "^0.5.5",
+    "ts-node": "1.2.2",
     "tslint": "3.9.0",
     "typings": "1.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^2.5.2",
     "ts-node": "^0.5.5",
     "tslint": "3.9.0",
-    "typings": "0.8.1"
+    "typings": "1.3.2"
   },
   "peerDependencies": {
     "tslint": "3.9.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "minimalist": "1.0.0",
-    "mocha": "^2.4.5",
+    "mocha": "3.0.2",
     "rimraf": "^2.5.2",
     "ts-node": "^0.5.5",
     "tslint": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "mocha": "3.0.2",
     "rimraf": "^2.5.2",
     "ts-node": "1.2.2",
-    "tslint": "3.9.0",
+    "tslint": "3.14.0",
     "typings": "1.3.2"
   },
   "peerDependencies": {
-    "tslint": "3.9.0"
+    "tslint": "^3.9.0"
   },
   "dependencies": {
     "sprintf-js": "^1.0.3"

--- a/typings.json
+++ b/typings.json
@@ -2,10 +2,10 @@
   "name": "ng2lint",
   "dependencies": {},
   "devDependencies": {},
-  "ambientDependencies": {
-    "chai": "github:DefinitelyTyped/DefinitelyTyped/chai/chai.d.ts#9c25433c84251bfe72bf0030a95edbbb2c81c9d5",
-    "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#d6dd320291705694ba8e1a79497a908e9f5e6617",
-    "sprintf-js": "github:DefinitelyTyped/DefinitelyTyped/sprintf-js/sprintf-js.d.ts#147380f9d1255f779806270d80eea85e2c1af55f",
-    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#138ad74b9e8e6c08af7633964962835add4c91e2"
+  "globalDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "node": "registry:dt/node#6.0.0+20160807145350",
+    "sprintf-js": "registry:dt/sprintf-js#0.0.0+20160317120654"
   }
 }


### PR DESCRIPTION
Changes:

mocha 2.4.5 => 3.0.2
ts-node 0.5.5 => 1.2.2
tslint 3.9.0 => 3.14.0 (dev) ^3.9.0 (peer)
typings 0.8.1 => 1.3.2

Builds and runs tests successfully. The `peerDependencies` change is helpful for those who want to use a newer version of tslint with codelyzer.