### PR TITLE
fix(parseTemplate): migrate to the new private API

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,11 @@
   },
   "peerDependencies": {
     "tslint": "^3.9.0",
-    "@angular/compiler": "^2.0.0",
-    "@angular/core": "^2.0.0"
+    "@angular/compiler": "^2.0.2",
+    "@angular/core": "^2.0.2"
   },
   "dependencies": {
+    "escape-string-regexp": "^1.0.5",
     "sprintf-js": "^1.0.3"
   }
 }

--- a/src/angular/config.ts
+++ b/src/angular/config.ts
@@ -1,0 +1,1 @@
+export const INTERPOLATION: [string, string] = ['{{', '}}'];

--- a/src/angular/recursiveAngularExpressionVisitor.ts
+++ b/src/angular/recursiveAngularExpressionVisitor.ts
@@ -1,6 +1,9 @@
 import * as Lint from 'tslint/lib/lint';
 import * as ts from 'typescript';
 import * as e from '@angular/compiler/src/expression_parser/ast';
+import { INTERPOLATION } from './config';
+
+const escapeString = require('escape-string-regexp');
 
 export class RecursiveAngularExpressionVisitor extends Lint.RuleWalker implements e.AstVisitor {
   constructor(sourceFile: ts.SourceFile, options: Lint.IOptions,
@@ -47,8 +50,9 @@ export class RecursiveAngularExpressionVisitor extends Lint.RuleWalker implement
     // Note that we add the expression property in ng2Walker.
     // This is due an issue in the ParseSpan in the child expressions
     // of the interpolation AST.
-    const parts: string[] = (<any>ast).interpolateExpression.split(/\{\{|\}\}/g).map((s: string) => {
-      return s.replace('}}', '');
+    const regexp = new RegExp(escapeString(INTERPOLATION[0]) + '|' + escapeString(INTERPOLATION[1]), 'g');
+    const parts: string[] = (<any>ast).interpolateExpression.split(regexp).map((s: string) => {
+      return s.replace(INTERPOLATION[1], '');
     }).filter((e: string, i: number) => (i % 2));
     ast.expressions.forEach((e: any, i: number) => {
       // for {{

--- a/src/angular/templateParser.ts
+++ b/src/angular/templateParser.ts
@@ -1,19 +1,32 @@
 import { __core_private__ as r, NO_ERRORS_SCHEMA } from '@angular/core';
+import { INTERPOLATION } from './config';
 import * as compiler from '@angular/compiler';
 
 export const parseTemplate = (template: string) => {
   const _ = compiler.__compiler_private__;
+
   const TemplateParser = _.TemplateParser;
-  const DomElementSchemaRegistry = _.DomElementSchemaRegistry;
   const expressionParser = new _.Parser(new _.Lexer());
-  const elementSchemaRegistry = new DomElementSchemaRegistry();
+  const elementSchemaRegistry = new _.DomElementSchemaRegistry();
   const ngConsole = new r.Console();
   const htmlParser =
-      new compiler.I18NHtmlParser(new _.HtmlParser(), '', '');
+      new compiler.I18NHtmlParser(new _.HtmlParser());
   const tmplParser =
     new TemplateParser(expressionParser, elementSchemaRegistry, htmlParser, ngConsole, []);
+  const interpolation = INTERPOLATION;
+  const templateMetadata = {
+    encapsulation: 0,
+    template: template,
+    templateUrl: '',
+    styles: [],
+    styleUrls: [],
+    ngContentSelectors: [],
+    animations: [],
+    externalStylesheets: [],
+    interpolation
+  };
   const type = new compiler.CompileTypeMetadata({ diDeps: [] });
   return tmplParser.tryParse(
-      compiler.CompileDirectiveMetadata.create({ type }),
-      template, [], [], [NO_ERRORS_SCHEMA], null).templateAst;
+      compiler.CompileDirectiveMetadata.create({ type, template: templateMetadata }),
+      template, [], [], [NO_ERRORS_SCHEMA], '').templateAst;
 };


### PR DESCRIPTION
1. Migrate to the newest private API.
2. Externalize the interpolation config.