### PR TITLE
fix(pipeNaming): do not fail on empty @Pipe decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ os:
 branches:
   only: master
 
+before_install: npm i rxjs@5.0.0-beta.12 @angular/core @angular/compiler zone.js@0.6.25
+
 script: npm run tscv && npm run lint && npm t
 

--- a/src/angular/ng2Walker.ts
+++ b/src/angular/ng2Walker.ts
@@ -138,11 +138,14 @@ export class Ng2Walker extends Lint.RuleWalker {
 
   protected visitClassDecorator(decorator: ts.Decorator) {
     let name = getDecoratorName(decorator);
+    // Not invoked @Component or @Pipe, or @Directive
+    if (!(<ts.CallExpression>decorator.expression).arguments ||
+        !(<ts.CallExpression>decorator.expression).arguments.length ||
+        !(<ts.ObjectLiteralExpression>(<ts.CallExpression>decorator.expression).arguments[0]).properties) {
+      return;
+    }
+
     if (name === 'Component') {
-      if (!(<ts.CallExpression>decorator.expression).arguments.length ||
-          !(<ts.ObjectLiteralExpression>(<ts.CallExpression>decorator.expression).arguments[0]).properties) {
-        return;
-      }
       this.visitNg2Component(<ts.ClassDeclaration>decorator.parent, decorator);
       const inlineTemplate = (<ts.ObjectLiteralExpression>
           (<ts.CallExpression>decorator.expression).arguments[0])
@@ -165,6 +168,8 @@ export class Ng2Walker extends Lint.RuleWalker {
       }
     } else if (name === 'Directive') {
       this.visitNg2Directive(<ts.ClassDeclaration>decorator.parent, decorator);
+    } else if (name === 'Pipe') {
+      this.visitNg2Pipe(<ts.ClassDeclaration>decorator.parent, decorator);
     }
   }
 
@@ -208,6 +213,8 @@ export class Ng2Walker extends Lint.RuleWalker {
   protected visitNg2Component(controller: ts.ClassDeclaration, decorator: ts.Decorator) {}
 
   protected visitNg2Directive(controller: ts.ClassDeclaration, decorator: ts.Decorator) {}
+
+  protected visitNg2Pipe(controller: ts.ClassDeclaration, decorator: ts.Decorator) {}
 
   protected visitNg2Input(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {}
 

--- a/src/angular/recursiveAngularExpressionVisitor.ts
+++ b/src/angular/recursiveAngularExpressionVisitor.ts
@@ -54,6 +54,7 @@ export class RecursiveAngularExpressionVisitor extends Lint.RuleWalker implement
     const parts: string[] = (<any>ast).interpolateExpression.split(regexp).map((s: string) => {
       return s.replace(INTERPOLATION[1], '');
     }).filter((e: string, i: number) => (i % 2));
+
     ast.expressions.forEach((e: any, i: number) => {
       // for {{
       this.basePosition += ast.strings[i].length + 2;

--- a/src/componentClassSuffixRule.ts
+++ b/src/componentClassSuffixRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 export class ClassMetadataWalker extends Ng2Walker {
   visitNg2Component(controller:ts.ClassDeclaration, decorator:ts.Decorator) {
     let name = controller.name;
-    let className:string = name.text;
+    let className: string = name.text;
     if (!Rule.validate(className)) {
       this.addFailure(
         this.createFailure(

--- a/src/pipeImpureRule.ts
+++ b/src/pipeImpureRule.ts
@@ -1,6 +1,7 @@
 import * as Lint from 'tslint/lib/lint';
 import * as ts from 'typescript';
 import {sprintf} from 'sprintf-js';
+import {Ng2Walker} from './angular/ng2Walker';
 import SyntaxKind = require('./util/syntaxKind');
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -12,20 +13,14 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-export class ClassMetadataWalker extends Lint.RuleWalker {
+export class ClassMetadataWalker extends Ng2Walker {
 
   constructor(sourceFile:ts.SourceFile, private rule:Rule) {
     super(sourceFile, rule.getOptions());
   }
 
-  visitClassDeclaration(node:ts.ClassDeclaration) {
-    let className = node.name.text;
-    let decorators = <ts.Decorator[]>node.decorators || [];
-    decorators.filter(d => {
-      let baseExpr = <any>d.expression || {};
-      return baseExpr.expression.text === 'Pipe'
-    }).forEach(this.validateProperties.bind(this, className));
-    super.visitClassDeclaration(node);
+  visitNg2Pipe(controller: ts.ClassDeclaration, decorator: ts.Decorator) {
+    this.validateProperties(controller.name.text, decorator);
   }
 
   private validateProperties(className:string, pipe:any) {

--- a/src/pipeNamingRule.ts
+++ b/src/pipeNamingRule.ts
@@ -2,6 +2,7 @@ import * as Lint from 'tslint/lib/lint';
 import * as ts from 'typescript';
 import {sprintf} from 'sprintf-js';
 import SyntaxKind = require('./util/syntaxKind');
+import {Ng2Walker} from './angular/ng2Walker';
 import {SelectorValidator} from './util/selectorValidator';
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -43,20 +44,15 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-export class ClassMetadataWalker extends Lint.RuleWalker {
+export class ClassMetadataWalker extends Ng2Walker {
 
   constructor(sourceFile:ts.SourceFile, private rule:Rule) {
     super(sourceFile, rule.getOptions());
   }
 
-  visitClassDeclaration(node:ts.ClassDeclaration) {
-    let className = node.name.text;
-    let decorators = <ts.Decorator[]>node.decorators || [];
-    decorators.filter(d => {
-      let baseExpr = <any>d.expression || {};
-      return baseExpr.expression.text === 'Pipe'
-    }).forEach(this.validateProperties.bind(this, className));
-    super.visitClassDeclaration(node);
+  visitNg2Pipe(controller: ts.ClassDeclaration, decorator: ts.Decorator) {
+    let className = controller.name.text;
+    this.validateProperties(className, decorator);
   }
 
   private validateProperties(className:string, pipe:any) {

--- a/test/directiveClassSuffix.spec.ts
+++ b/test/directiveClassSuffix.spec.ts
@@ -33,6 +33,15 @@ describe('directive-class-suffix', () => {
         });
     });
 
+    describe('not called decorator', () => {
+        it('should not fail when @Directive is not called', () => {
+            let source = `
+            @Directive
+            class TestDirective {}`;
+            assertSuccess('directive-class-suffix', source);
+        });
+    });
+
     describe('valid directive class', () => {
         it('should succeed when is used @Component decorator', () => {
             let source = `

--- a/test/pipeImpureRule.spec.ts
+++ b/test/pipeImpureRule.spec.ts
@@ -33,6 +33,15 @@ describe('pipe-impure', () => {
         });
     });
 
+    describe('empty pipe', () => {
+        it('should not fail', () => {
+            let source = `
+                    @Pipe
+                    class Test {}`;
+            assertSuccess('pipe-impure', source);
+        });
+    });
+
     describe('default pipe', () => {
         it('should succeed when Pipe pure property is not set', () => {
             let source = `

--- a/test/pipeNamingRule.spec.ts
+++ b/test/pipeNamingRule.spec.ts
@@ -60,6 +60,15 @@ describe('pipe-naming', () => {
         });
     });
 
+    describe('empty pipe', () => {
+        it('should not fail when @Pipe not invoked', () => {
+            let source = `
+                    @Pipe
+                    class Test {}`;
+            assertSuccess('pipe-naming', source, ['camelCase', 'ng']);
+        });
+    });
+
     describe('valid pipe name', () => {
         it('should succeed when set valid name with prefix ng in @Pipe', () => {
             let source = `


### PR DESCRIPTION
Add `visitNg2Pipe` method in `NgwWalker`.
Refactor pipe related rules to use `Ng2Walker`.

Fix #111