### PR TITLE
Added no-focused-test and no-skipped-test rules

### DIFF
--- a/src/noFocusedTestRule.ts
+++ b/src/noFocusedTestRule.ts
@@ -1,0 +1,38 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: 'no-focused-test',
+        description: 'Disallows `fit` and `fdescribe` function invocations.',
+        rationale: Lint.Utils.dedent`
+            Using 'fit' or 'fdescribe' causes only a subset of tests to run,
+            which can easily go unnoticed and lead to a build passing where
+            it should fail.
+        `,
+        optionsDescription: 'Not configurable.',
+        options: null,
+        optionExamples: ['true'],
+        type: 'functionality',
+    };
+
+    public static FAILURE_STRING = 'Focused tests are not allowed';
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoFocusedTestWalker(sourceFile, this.getOptions()));
+    }
+}
+
+// The walker takes care of all the work.
+class NoFocusedTestWalker extends Lint.RuleWalker {
+    public visitCallExpression(node: ts.CallExpression) {
+        // create a failure at the current positionn
+        let nodeText = node.getText();
+        if (nodeText.indexOf('fit') === 0 || nodeText.indexOf('fdescribe') === 0) {
+            this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING));
+        }
+
+        // call the base version of this visitor to actually parse this node
+        super.visitCallExpression(node);
+    }
+}

--- a/src/noSkippedTestRule.ts
+++ b/src/noSkippedTestRule.ts
@@ -1,0 +1,38 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint/lib/lint';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: 'no-skipped-test',
+        description: 'Disallows `xit` and `xdescribe` function invocations.',
+        rationale: Lint.Utils.dedent`
+            Using 'xit' or 'xdescribe' causes only a subset of tests to run,
+            which can easily go unnoticed and lead to a build passing where
+            it should fail.
+        `,
+        optionsDescription: 'Not configurable.',
+        options: null,
+        optionExamples: ['true'],
+        type: 'functionality',
+    };
+
+    public static FAILURE_STRING = 'Skipped tests are not allowed';
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoFocusedTestWalker(sourceFile, this.getOptions()));
+    }
+}
+
+// The walker takes care of all the work.
+class NoFocusedTestWalker extends Lint.RuleWalker {
+    public visitCallExpression(node: ts.CallExpression) {
+        // create a failure at the current positionn
+        let nodeText = node.getText();
+        if (nodeText.indexOf('xit') === 0 || nodeText.indexOf('xdescribe') === 0) {
+            this.addFailure(this.createFailure(node.getStart(), 1, Rule.FAILURE_STRING));
+        }
+
+        // call the base version of this visitor to actually parse this node
+        super.visitCallExpression(node);
+    }
+}

--- a/test/noFocusedTestRule.spec.ts
+++ b/test/noFocusedTestRule.spec.ts
@@ -1,0 +1,50 @@
+import {assertFailure, assertSuccess} from './testHelper';
+
+describe('no-focused-test', () => {
+    describe('invalid function call', () => {
+        it('should fail when we focus on an individual test', () => {
+            let source = `fit('this is a test', function() {
+                expect(1).toBe(2);
+            });`;
+            assertFailure('no-focused-test', source, {
+                message: 'Focused tests are not allowed',
+                startPosition: {
+                    line: 0,
+                    character: 0
+                },
+                endPosition: {
+                    line: 0,
+                    character: 1
+                }
+            });
+        });
+
+        it('should fail when we focus on an individual describe', () => {
+            let source = `fdescribe('here are some tests', function() {
+                it('this is a test', function() {
+                    expect(1).toBe(2);
+                });
+            });`;
+            assertFailure('no-focused-test', source, {
+                message: 'Focused tests are not allowed',
+                startPosition: {
+                    line: 0,
+                    character: 0
+                },
+                endPosition: {
+                    line: 0,
+                    character: 1
+                }
+            });
+        });
+    });
+    describe('valid function call', () => {
+        it('should succeed, when we are not using a focused test', () => {
+            let source = `
+              it('this is a test', function() {
+                  expect(1).toBe(2);
+              })`;
+            assertSuccess('no-focused-test', source);
+        });
+    });
+});

--- a/test/noSkipTestRule.spec.ts
+++ b/test/noSkipTestRule.spec.ts
@@ -1,0 +1,50 @@
+import {assertFailure, assertSuccess} from './testHelper';
+
+describe('no-skipped-test', () => {
+    describe('invalid function call', () => {
+        it('should fail when we skip an individual test', () => {
+            let source = `xit('this is a test', function() {
+                expect(1).toBe(2);
+            });`;
+            assertFailure('no-skipped-test', source, {
+                message: 'Skipped tests are not allowed',
+                startPosition: {
+                    line: 0,
+                    character: 0
+                },
+                endPosition: {
+                    line: 0,
+                    character: 1
+                }
+            });
+        });
+
+        it('should fail when we skip an individual describe', () => {
+            let source = `xdescribe('here are some tests', function() {
+                it('this is a test', function() {
+                    expect(1).toBe(2);
+                });
+            });`;
+            assertFailure('no-skipped-test', source, {
+                message: 'Skipped tests are not allowed',
+                startPosition: {
+                    line: 0,
+                    character: 0
+                },
+                endPosition: {
+                    line: 0,
+                    character: 1
+                }
+            });
+        });
+    });
+    describe('valid function call', () => {
+        it('should succeed, when we are not using a skipped test', () => {
+            let source = `
+              it('this is a test', function() {
+                  expect(1).toBe(2);
+              })`;
+            assertSuccess('no-focused-test', source);
+        });
+    });
+});


### PR DESCRIPTION
This pull request adds two new linting rules to disallow focused tests and skipped tests (fit, fdescribe, xit and xdescribe), as per issue #133.