### PR TITLE
docs(readme): add visual studio 2015 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Codelyzer should work out of the box with Atom but for VSCode you will have to o
 }
 ```
 
+> Note: In Visual Studio 2015, for codelyzer to work, you must *at least* have .NET Core >= **1.1.0-preview1** and Update 3 installed. You can find the [1.1.0 download here](https://github.com/dotnet/core/blob/master/release-notes/preview-download.md). 
+
 Now you should have the following result:
 
 ![VSCode Codelyzer](http://gifyu.com/images/cd.gif)


### PR DESCRIPTION
**Still investigating, this might not fix it just yet**

Added:

> Note: In Visual Studio 2015, for codelyzer to work, you must *at least* have .NET Core >= **1.1.0-preview1** and Update 3 installed. You can find the [1.1.0 download here](https://github.com/dotnet/core/blob/master/release-notes/preview-download.md). 

Codelyzer in action in Visual Studio 2015 update 3 with the latest .NET Core 1.1.0-preview1 installed:

![image](https://cloud.githubusercontent.com/assets/2574412/20151768/64966f1e-a689-11e6-9dfd-1856f5542339.png)


Closes #141