### PR TITLE
chore: migrate to angular 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/mgechev/codelyzer#readme",
   "devDependencies": {
-    "@angular/compiler": "^2.1.1",
-    "@angular/core": "^2.1.1",
+    "@angular/compiler": "^2.2.0",
+    "@angular/core": "^2.2.0",
     "@types/chai": "^3.4.33",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",
@@ -62,8 +62,8 @@
   },
   "peerDependencies": {
     "tslint": "^3.9.0",
-    "@angular/compiler": "~2.1.1",
-    "@angular/core": "~2.1.1"
+    "@angular/compiler": "~2.2.0",
+    "@angular/core": "~2.2.0"
   },
   "dependencies": {
     "css-selector-tokenizer": "^0.7.0",


### PR DESCRIPTION
I cannot update my project because codelyzer peer dependencies are not compatible with the current version, let's hope this gets merged and released soon.