### PR TITLE
feat(templateWalker): add template references support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:links": "ts-node build/links.ts --src ./dist",
     "prepare:package": "cat package.json | ts-node build/package.ts > dist/package.json",
     "test": "rimraf dist && tsc && mocha dist/test/*.js dist/test/**/*.js",
-    "test:watch": "rimraf dist && tsc && mocha dist/test/*.js dist/test/**/*.js --watch",
+    "test:watch": "rimraf dist && tsc && mocha dist/test/** dist/test/** --watch",
     "tscv": "tsc --version",
     "tsc": "tsc",
     "tsc:watch": "tsc --w"

--- a/src/angular/ng2Walker.ts
+++ b/src/angular/ng2Walker.ts
@@ -101,7 +101,7 @@ export class Ng2Walker extends Lint.RuleWalker {
           }
         } catch (e) {
           // stderr breaks the VSCode extension
-          // console.error('Cannot parse the template of', ((<any>decorator.parent || {}).name || {}).text);
+          console.error(e);
         }
       }
       const inlineStyles = getDecoratorPropertyInitializer(decorator, 'styles');

--- a/src/angular/ng2Walker.ts
+++ b/src/angular/ng2Walker.ts
@@ -94,14 +94,12 @@ export class Ng2Walker extends Lint.RuleWalker {
       if (inlineTemplate) {
         try {
           if (isSimpleTemplateString(inlineTemplate)) {
-
-            const templateAst = parseTemplate(inlineTemplate.text);
+            const templateAst = parseTemplate(inlineTemplate.text, ((this.getOptions() || []).pop() || ({} as any)).directives);
             this.visitNg2TemplateHelper(templateAst,
                 <ts.ClassDeclaration>decorator.parent, inlineTemplate.pos + 2); // skip the quote
           }
         } catch (e) {
-          // stderr breaks the VSCode extension
-          console.error(e);
+          // console.error('Cannot parse the template of', ((<any>decorator.parent || {}).name || {}).text);
         }
       }
       const inlineStyles = getDecoratorPropertyInitializer(decorator, 'styles');

--- a/src/angular/templates/basicTemplateAstVisitor.ts
+++ b/src/angular/templates/basicTemplateAstVisitor.ts
@@ -106,16 +106,20 @@ export class BasicTemplateAstVisitor extends Lint.RuleWalker implements ast.Temp
   }
 
   visitElement(element: ast.ElementAst, context: any): any {
+    const references = element.references.map(r => r.name);
+    const oldVariables = this._variables;
+    this._variables = this._variables.concat(references);
+    element.references.forEach(r => this.visit(r, context));
     element.inputs.forEach(i => this.visit(i, context));
     element.outputs.forEach(o => this.visit(o, context));
     element.attrs.forEach(a => this.visit(a, context));
     element.children.forEach(e => this.visit(e, context));
-    element.references.forEach(r => this.visit(r, context));
     element.directives.forEach(d => this.visit(d, context));
+    // Outside the scope of the element
+    this._variables = oldVariables;
   }
 
   visitReference(ast: ast.ReferenceAst, context: any): any {
-    // console.log(ast);
   }
 
   visitVariable(ast: ast.VariableAst, context: any): any {

--- a/src/angular/templates/templateParser.ts
+++ b/src/angular/templates/templateParser.ts
@@ -2,7 +2,7 @@ import { __core_private__ as r, NO_ERRORS_SCHEMA } from '@angular/core';
 import { INTERPOLATION } from '../config';
 import * as compiler from '@angular/compiler';
 
-const dummyMetadataFactory = (exportAs: string, selector: string) => {
+const dummyMetadataFactory = (selector: string, exportAs: string) => {
   return {
     inputs: {},
     outputs: {},
@@ -33,10 +33,13 @@ const dummyMetadataFactory = (exportAs: string, selector: string) => {
 };
 
 const defaultDirectives = [
-  dummyMetadataFactory('ngForm', 'form')
+  dummyMetadataFactory('form', 'ngForm')
 ];
 
-export const parseTemplate = (template: string) => {
+export const parseTemplate = (template: string, directives: { selector: string, exportAs: string }[] = []) => {
+  directives.forEach(d =>
+    this.defaultDirectives.push(dummyMetadataFactory(d.selector, d.exportAs)));
+
   const TemplateParser = <any>compiler.TemplateParser;
   const expressionParser = new compiler.Parser(new compiler.Lexer());
   const elementSchemaRegistry = new compiler.DomElementSchemaRegistry();

--- a/src/angular/templates/templateParser.ts
+++ b/src/angular/templates/templateParser.ts
@@ -2,6 +2,40 @@ import { __core_private__ as r, NO_ERRORS_SCHEMA } from '@angular/core';
 import { INTERPOLATION } from '../config';
 import * as compiler from '@angular/compiler';
 
+const dummyMetadataFactory = (exportAs: string, selector: string) => {
+  return {
+    inputs: {},
+    outputs: {},
+    hostListeners: {},
+    hostProperties: {},
+    hostAttributes: {},
+    isSummary: true,
+    type: {
+      diDeps: [],
+      lifecycleHooks: [],
+      isHost: false
+    },
+    isComponent: false,
+    selector,
+    exportAs,
+    providers: [],
+    viewProviders: [],
+    queries: [],
+    entryComponents: [],
+    changeDetection: 0,
+    template: {
+      isSummary: true,
+      animations: [],
+      ngContentSelectors: [],
+      encapsulation: 0
+    }
+  };
+};
+
+const defaultDirectives = [
+  dummyMetadataFactory('ngForm', 'form')
+];
+
 export const parseTemplate = (template: string) => {
   const TemplateParser = <any>compiler.TemplateParser;
   const expressionParser = new compiler.Parser(new compiler.Lexer());
@@ -34,5 +68,5 @@ export const parseTemplate = (template: string) => {
   const type = new compiler.CompileTypeMetadata({ diDeps: [] });
   return tmplParser.tryParse(
       compiler.CompileDirectiveMetadata.create({ type, template: templateMetadata }),
-      template, [], [], [NO_ERRORS_SCHEMA], '').templateAst;
+      template, defaultDirectives, [], [NO_ERRORS_SCHEMA], '').templateAst;
 };

--- a/test/noAccessMissingMemberRule.spec.ts
+++ b/test/noAccessMissingMemberRule.spec.ts
@@ -287,6 +287,29 @@ describe('no-access-missing-member', () => {
           }
        });
     });
+
+
+    it('should throw when template ref used outside component scope', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<form #todoForm="ngForm"></form><button [disabled]="!todoForm.form.valid"></button>'
+        })
+        class Test {
+          foo: number;
+        }`;
+        assertFailure('no-access-missing-member', source, {
+          message: 'The property "todoForm" that you\'re trying to access does not exist in the class declaration.',
+          startPosition: {
+            line: 3,
+            character: 74
+          },
+          endPosition: {
+            line: 3,
+            character: 82
+          }
+       });
+    });
   });
 
   describe('valid expressions', () => {
@@ -300,6 +323,20 @@ describe('no-access-missing-member', () => {
           foo: number;
         }`;
         assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should support custom template refs', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<form #todoForm="bar"><button [disabled]="!todoForm.form.valid"></button></form>'
+        })
+        class Test {
+          foo: number;
+        }`;
+        assertSuccess('no-access-missing-member', source, [{
+          directives: [{ selector: 'baz', exportAs: 'bar' }]
+        }]);
     });
 
     it('should succeed with declared property', () => {

--- a/test/noAccessMissingMemberRule.spec.ts
+++ b/test/noAccessMissingMemberRule.spec.ts
@@ -290,11 +290,23 @@ describe('no-access-missing-member', () => {
   });
 
   describe('valid expressions', () => {
+    it('should succeed with "ngForm" ref', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<form #todoForm="ngForm"><button [disabled]="!todoForm.form.valid"></button></form>'
+        })
+        class Test {
+          foo: number;
+        }`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
     it('should succeed with declared property', () => {
       let source = `
         @Component({
           selector: 'foobar',
-          template: '<div>{{ foo }}</div>
+          template: '<div>{{ foo }}</div>'
         })
         class Test {
           foo: number;


### PR DESCRIPTION
Fix #151

Workaround for template references until we move to the official Angular service which is context-aware.