### PR TITLE
fix(rules): handle index access in missing property access in templates

### DIFF
--- a/src/noAccessMissingMemberRule.ts
+++ b/src/noAccessMissingMemberRule.ts
@@ -41,7 +41,7 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
 
     ast.receiver.visit(this);
     // Do not support nested properties yet
-    if (ast.receiver && (<any>ast.receiver).name) {
+    if (ast.receiver && ((<any>ast.receiver).name || (<any>ast.receiver).key)) {
       let receiver: any = ast.receiver;
       while (receiver.receiver.name) {
         receiver = receiver.receiver;

--- a/src/templatesUsePublicRule.ts
+++ b/src/templatesUsePublicRule.ts
@@ -27,7 +27,7 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
 
   private doCheck(ast: e.MethodCall | e.PropertyRead | e.PropertyWrite, type: DeclarationType, context: any): any {
     // Do not support nested properties yet
-    if (ast.receiver && (<any>ast.receiver).name) {
+    if (ast.receiver && ((<any>ast.receiver).name || (<any>ast.receiver).key)) {
       let receiver: any = ast.receiver;
       while (receiver.receiver.name) {
         receiver = receiver.receiver;

--- a/test/noAccessMissingMemberRule.spec.ts
+++ b/test/noAccessMissingMemberRule.spec.ts
@@ -575,6 +575,18 @@ describe('no-access-missing-member', () => {
         assertSuccess('no-access-missing-member', source);
     });
 
+    it('should work with array element access', () => {
+      let source = `
+        @Component({
+          template: '{{ names[0].firstName }}'
+        })
+        class Test {
+          get names() {
+            return [{ firstName: 'foo' }];
+          }
+        }`;
+        assertSuccess('no-access-missing-member', source);
+    });
 //    TODO
 //    it('should work with getters', () => {
 //      let source = `

--- a/test/templatesUsePublicRule.spec.ts
+++ b/test/templatesUsePublicRule.spec.ts
@@ -196,5 +196,18 @@ describe('templates-use-public', () => {
         }`;
         assertSuccess('templates-use-public', source);
     });
+
+
+    it('should succeed on public nested props', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<div>{{ foo[1].baz.bar }}</div>
+        })
+        class Test {
+          foo: any;
+        }`;
+        assertSuccess('templates-use-public', source);
+    });
   });
 });


### PR DESCRIPTION
Fix #173