### PR TITLE
Atom fatal error from app-root-path

### DIFF
--- a/src/angular/config.ts
+++ b/src/angular/config.ts
@@ -58,9 +58,9 @@ export const Config: Config = {
   logLevel: BUILD_TYPE === 'dev' ? LogLevel.Debug : LogLevel.None
 };
 
-const root = require('app-root-path');
 
 try {
+  const root = require('app-root-path');
   let newConfig = require(root.path + '/.codelyzer');
   Object.assign(Config, newConfig);
 } catch (e) {}


### PR DESCRIPTION
In Atom Editor when using linter-tslint and codelyzer 2.0.0-beta.1 we're unable to lint files currently because app-root-path fails. I'm not sure why? But putting it inside the try catch to fail silently stops it from being broken.