### PR TITLE
Updating visibility and export to fix d.ts build error

### DIFF
--- a/src/noAttributeParameterDecoratorRule.ts
+++ b/src/noAttributeParameterDecoratorRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ' consider construction of type "@Input() %s: string"';
 
 
-    static walkerBuilder = all(
+    private static walkerBuilder = all(
         validate(SyntaxKind.current().Constructor)((node: ts.ConstructorDeclaration) => {
             const syntaxKind = SyntaxKind.current();
             return Maybe.lift(node.parent)

--- a/src/walkerFactory/walkerFactory.ts
+++ b/src/walkerFactory/walkerFactory.ts
@@ -4,7 +4,8 @@ import {IOptions} from 'tslint';
 import {ComponentMetadata} from '../angular/metadata';
 import {F1, Maybe} from '../util/function';
 
-type Walkable = 'Ng2Component';
+// Walkable types
+export type Walkable = 'Ng2Component';
 
 export function allNg2Component(): WalkerBuilder<'Ng2Component'> {
     return new Ng2ComponentWalkerBuilder();
@@ -14,7 +15,7 @@ export class Failure {
     constructor(public node: ts.Node, public message: string) {}
 }
 
-interface WalkerBuilder<T extends Walkable> {
+export interface WalkerBuilder<T extends Walkable> {
     where: (validate: F1<ComponentMetadata, Maybe<Failure>>) => WalkerBuilder<T>;
     build: (sourceFile: ts.SourceFile, options: IOptions) => Ng2Walker;
 }

--- a/src/walkerFactory/walkerFn.ts
+++ b/src/walkerFactory/walkerFn.ts
@@ -5,19 +5,17 @@ import {ComponentMetadata} from '../angular/metadata';
 import {F1, F2, Maybe} from '../util/function';
 import {Failure} from './walkerFactory';
 
-type ComponentWalkable = 'Ng2Component';
+export type Validator = NodeValidator | ComponentValidator;
+export type ValidateFn<T> = F2<T, IOptions, Maybe<Failure[]>>;
+export type WalkerOptions = any;
 
-type Validator = NodeValidator | ComponentValidator;
-type ValidateFn<T> = F2<T, IOptions, Maybe<Failure[]>>;
-type WalkerOptions = any;
-
-interface NodeValidator {
+export interface NodeValidator {
     kind: 'Node';
     validate: ValidateFn<ts.Node>;
 }
 
-interface ComponentValidator {
-    kind: ComponentWalkable;
+export interface ComponentValidator {
+    kind: 'Ng2Component';
     validate: ValidateFn<ComponentMetadata>;
 }
 


### PR DESCRIPTION
Fixes errors from building with declaration file (#221)

Tested with `npm run tsc -- -p tsconfig-release.json`.

Making `walkerBuilder` private as it should be local to the Rule class.