### PR TITLE
fix(templatesUsePublicRule): Pass member name back through error

### DIFF
--- a/src/templatesUsePublicRule.ts
+++ b/src/templatesUsePublicRule.ts
@@ -41,7 +41,7 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
         .some(m => m.kind === SyntaxKind.current().PrivateKeyword || m.kind === SyntaxKind.current().ProtectedKeyword);
       const width = ast.name.length;
       if (!isPublic) {
-        const failureString = 'You can bind only to public class members.';
+        const failureString = `You can bind only to public class members. ${member.name.getText()} is not a public class member.`;
         this.addFailure(this.createFailure(ast.span.start, width, failureString));
       }
     }

--- a/src/templatesUsePublicRule.ts
+++ b/src/templatesUsePublicRule.ts
@@ -41,7 +41,7 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
         .some(m => m.kind === SyntaxKind.current().PrivateKeyword || m.kind === SyntaxKind.current().ProtectedKeyword);
       const width = ast.name.length;
       if (!isPublic) {
-        const failureString = `You can bind only to public class members. ${member.name.getText()} is not a public class member.`;
+        const failureString = `You can bind only to public class members. "${member.name.getText()}" is not a public class member.`;
         this.addFailure(this.createFailure(ast.span.start, width, failureString));
       }
     }

--- a/test/templatesUsePublicRule.spec.ts
+++ b/test/templatesUsePublicRule.spec.ts
@@ -12,7 +12,7 @@ describe('templates-use-public', () => {
           constructor(private foo: number) {}
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 24
@@ -34,7 +34,7 @@ describe('templates-use-public', () => {
           private foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -56,7 +56,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -78,7 +78,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -100,7 +100,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 35
@@ -122,7 +122,7 @@ describe('templates-use-public', () => {
           protected foo() {};
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members.',
+          message: 'You can bind only to public class members. foo is not a public class member.',
           startPosition: {
             line: 3,
             character: 33

--- a/test/templatesUsePublicRule.spec.ts
+++ b/test/templatesUsePublicRule.spec.ts
@@ -12,7 +12,7 @@ describe('templates-use-public', () => {
           constructor(private foo: number) {}
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 24
@@ -34,7 +34,7 @@ describe('templates-use-public', () => {
           private foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -56,7 +56,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -78,7 +78,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 29
@@ -100,7 +100,7 @@ describe('templates-use-public', () => {
           protected foo: number;
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 35
@@ -122,7 +122,7 @@ describe('templates-use-public', () => {
           protected foo() {};
         }`;
         assertFailure('templates-use-public', source, {
-          message: 'You can bind only to public class members. foo is not a public class member.',
+          message: 'You can bind only to public class members. "foo" is not a public class member.',
           startPosition: {
             line: 3,
             character: 33


### PR DESCRIPTION
Pass the class member name to the error for more clarification

fixes #229