### PR TITLE
docs(meta): add metadata to all rules

### DIFF
--- a/src/componentClassSuffixRule.ts
+++ b/src/componentClassSuffixRule.ts
@@ -10,6 +10,26 @@ import {Ng2Walker} from './angular/ng2Walker';
 
 export class Rule extends Lint.Rules.AbstractRule {
 
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'component-class-suffix',
+    type: 'style',
+    description: `Classes decorated with @Component must have suffix "Component" (or custom) in their name.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#02-03.`,
+    rationale: `Consistent conventions make it easy to quickly identify and reference assets of different types.`,
+    options: {
+      type: 'array',
+      items: {
+        type: 'string',
+      }
+    },
+    optionExamples: [
+      `true`,
+      `[true, "Component", "View"]`
+    ],
+    optionsDescription: `Supply a list of allowed component suffixes. Defaults to "Component".`,
+    typescriptOnly: true,
+  };
+
     static FAILURE: string = 'The name of the class %s should end with the suffix %s ($$02-03$$)';
 
     static validate(className: string, suffixList: string[]): boolean {

--- a/src/componentSelectorRule.ts
+++ b/src/componentSelectorRule.ts
@@ -1,6 +1,64 @@
 import {SelectorRule} from './selectorNameBase';
+import * as Lint from 'tslint';
 
 export class Rule extends SelectorRule {
+
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'component-selector',
+    type: 'style',
+    description: `Component selectors should follow given naming rules.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#02-07, https://angular.io/styleguide#!#05-02, ` +
+    `and https://angular.io/styleguide#!#05-03.`,
+    rationale: Lint.Utils.dedent`
+    * Consistent conventions make it easy to quickly identify and reference assets of different types.
+    * Makes it easier to promote and share the component in other apps.
+    * Components are easy to identify in the DOM.
+    * Keeps the element names consistent with the specification for Custom Elements.
+    * Components have templates containing HTML and optional Angular template syntax.
+        * They display content. Developers place components on the page as they would native HTML elements and WebComponents.
+    * It is easier to recognize that a symbol is a component by looking at the template's HTML.
+    `,
+    options: {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["element", "attribute"]
+        },
+        {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "enum": ["kebab-case", "camelCase"]
+        }
+      ],
+      "minItems": 3,
+      "maxItems": 3
+    },
+    optionExamples: [
+      `["element", "my-prefix", "kebab-case"]`,
+      `["element", ["ng", "ngx"], "kebab-case"]`,
+      `["attribute", "myPrefix", "camelCase"]`,
+    ],
+    optionsDescription: Lint.Utils.dedent`
+    Options accept three obligatory items as an array:
+    
+    1. \`"element"\` or \`"attribute"\` forces components either to be elements or attributes.
+    2. A single prefix (string) or array of prefixes (strings) which have to be used in component selectors.
+    3. \`"kebab-case"\` or \`"camelCase"\` allows you to pick a case.
+    `,
+    typescriptOnly: true,
+  };
+
   public handleType = 'Component';
   public getTypeFailure():any { return 'The selector of the component "%s" should be used as %s ($$05-03$$)'; }
   public getNameFailure():any { return 'The selector of the component "%s" should be named %s ($$05-02$$)'; }

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -6,6 +6,27 @@ import {Ng2Walker} from './angular/ng2Walker';
 import {DirectiveMetadata} from './angular/metadata';
 
 export class Rule extends Lint.Rules.AbstractRule {
+
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'directive-class-suffix',
+    type: 'style',
+    description: `Classes decorated with @Directive must have suffix "Directive" (or custom) in their name.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#02-03.`,
+    rationale: `Consistent conventions make it easy to quickly identify and reference assets of different types.`,
+    options: {
+      type: 'array',
+      items: {
+        type: 'string',
+      }
+    },
+    optionExamples: [
+      `true`,
+      `[true, "Directive", "MySuffix"]`,
+    ],
+    optionsDescription: `Supply a list of allowed component suffixes. Defaults to "Directive".`,
+    typescriptOnly: true,
+  };
+
   static FAILURE:string = 'The name of the class %s should end with the suffix %s ($$02-03$$)';
 
   static validate(className: string, suffix: string):boolean {

--- a/src/directiveSelectorRule.ts
+++ b/src/directiveSelectorRule.ts
@@ -1,10 +1,66 @@
 import {SelectorRule} from './selectorNameBase';
+import * as Lint from 'tslint';
 
 export class Rule extends SelectorRule {
+
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'directive-selector',
+    type: 'style',
+    description: `Directive selectors should follow given naming rules.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#02-07, https://angular.io/styleguide#!#05-02, ` +
+    `and https://angular.io/styleguide#!#05-03.`,
+    rationale: Lint.Utils.dedent`
+    * Consistent conventions make it easy to quickly identify and reference assets of different types.
+    * Makes it easier to promote and share the directive in other apps.
+    * Directives are easy to identify in the DOM.
+    * It is easier to recognize that a symbol is a directive by looking at the template's HTML.
+    `,
+    options: {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["element", "attribute"]
+        },
+        {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "enum": ["kebab-case", "camelCase"]
+        }
+      ],
+      "minItems": 3,
+      "maxItems": 3
+    },
+    optionExamples: [
+      `["element", "my-prefix", "kebab-case"]`,
+      `["element", ["ng", "ngx"], "kebab-case"]`,
+      `["attribute", "myPrefix", "camelCase"]`,
+    ],
+    optionsDescription: Lint.Utils.dedent`
+    Options accept three obligatory items as an array:
+    
+    1. \`"element"\` or \`"attribute"\` forces components either to be elements or attributes.
+    2. A single prefix (string) or array of prefixes (strings) which have to be used in directive selectors.
+    3. \`"kebab-case"\` or \`"camelCase"\` allows you to pick a case.
+    `,
+    typescriptOnly: true,
+  };
+
   public handleType = 'Directive';
   public getTypeFailure():any { return 'The selector of the directive "%s" should be used as %s ($$02-06$$)'; }
   public getNameFailure():any { return 'The selector of the directive "%s" should be named %s ($$02-06$$)'; }
   getSinglePrefixFailure():any { return 'The selector of the directive "%s" should have prefix "%s" ($$02-08$$)'; }
   getManyPrefixFailure():any { return 'The selector of the directive "%s" should have one of the prefixes: %s ($$02-08$$)'; }
+
 }
 

--- a/src/importDestructuringSpacingRule.ts
+++ b/src/importDestructuringSpacingRule.ts
@@ -2,6 +2,16 @@ import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'import-destructing-spacing-rule',
+    type: 'style',
+    description: `Ensure consistent and tidy imports.`,
+    rationale: `Imports are easier for the reader to look at when they're tidy.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
   public static FAILURE_STRING = 'You need to leave whitespaces inside of the import statement\'s curly braces';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/invokeInjectableRule.ts
+++ b/src/invokeInjectableRule.ts
@@ -4,6 +4,17 @@ import {sprintf} from 'sprintf-js';
 import {Ng2Walker} from './angular/ng2Walker';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'invoke-injectable',
+    type: 'functionality',
+    description: `Ensures that @Injectable decorator is properly invoked.`,
+    rationale: `Application will fail mysteriously if we forget the parentheses.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE_STRING: string = 'You have to invoke @Injectable()';
 
   public apply(sourceFile:ts.SourceFile):Lint.RuleFailure[] {

--- a/src/noAccessMissingMemberRule.ts
+++ b/src/noAccessMissingMemberRule.ts
@@ -123,6 +123,17 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-access-missing-member',
+    type: 'functionality',
+    description: `Disallows using non-existing properties and methods from the component in templates.`,
+    rationale: `Such occurances in code are most likely a result of a typo.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE: string = 'The %s "%s" that you\'re trying to access does not exist in the class declaration.';
 
   public apply(sourceFile:ts.SourceFile): Lint.RuleFailure[] {

--- a/src/noAttributeParameterDecoratorRule.ts
+++ b/src/noAttributeParameterDecoratorRule.ts
@@ -8,6 +8,16 @@ import {isDecorator, withIdentifier, callExpression} from './util/astQuery';
 import {Failure} from './walkerFactory/walkerFactory';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-attribute-parameter-decorator-rule',
+    type: 'maintainability',
+    description: `Disallow usage of @Attribute decorator`,
+    rationale: `@Attribute is considered bad practice. Use @Input instead.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
     static FAILURE_STRING: string = 'In the constructor of class "%s",' +
         ' the parameter "%s" uses the @Attribute decorator, ' +
         'which is considered as a bad practice. Please,' +

--- a/src/noForwardRefRule.ts
+++ b/src/noForwardRefRule.ts
@@ -4,6 +4,17 @@ import {sprintf} from 'sprintf-js';
 import SyntaxKind = require('./util/syntaxKind');
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-forward-ref',
+    type: 'maintainability',
+    description: `Disallows usage of forward references for DI.`,
+    rationale: `The flow of DI is disrupted by using \`forwardRef\` and might make code more difficult to understand.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE_IN_CLASS: string = 'Avoid using forwardRef in class "%s"';
 
   static FAILURE_IN_VARIABLE: string = 'Avoid using forwardRef in variable "%s"';

--- a/src/noInputRenameRule.ts
+++ b/src/noInputRenameRule.ts
@@ -4,6 +4,17 @@ import {sprintf} from 'sprintf-js';
 import {Ng2Walker} from './angular/ng2Walker';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-input-rename-rule',
+    type: 'maintainability',
+    description: `Disallows renaming directive inputs by providing a string to the decorator.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#05-13.`,
+    rationale: `Two names for the same property (one private, one public) is inherently confusing.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
   static FAILURE_STRING:string = 'In the class "%s", the directive ' +
     'input property "%s" should not be renamed.' +
     'Please, consider the following use "@Input() %s: string"';

--- a/src/noOutputRenameRule.ts
+++ b/src/noOutputRenameRule.ts
@@ -4,6 +4,17 @@ import {sprintf} from 'sprintf-js';
 import {Ng2Walker} from './angular/ng2Walker';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-output-rename-rule',
+    type: 'maintainability',
+    description: `Disallows renaming directive outputs by providing a string to the decorator.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#05-13.`,
+    rationale: `Two names for the same property (one private, one public) is inherently confusing.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
   static FAILURE_STRING:string = 'In the class "%s", the directive output ' +
     'property "%s" should not be renamed.' +
     'Please, consider the following use "@Output() %s = new EventEmitter();"';

--- a/src/noUnusedCssRule.ts
+++ b/src/noUnusedCssRule.ts
@@ -139,6 +139,16 @@ class ElementFilterVisitor extends BasicTemplateAstVisitor {
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-unused-css-rule',
+    type: 'maintainability',
+    description: `Disallows having an unused CSS rule in the component's stylesheet.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE: string = 'The %s "%s" that you\'re trying to access does not exist in the class declaration.';
 
   public apply(sourceFile:ts.SourceFile): Lint.RuleFailure[] {

--- a/src/pipeImpureRule.ts
+++ b/src/pipeImpureRule.ts
@@ -5,6 +5,17 @@ import {Ng2Walker} from './angular/ng2Walker';
 import SyntaxKind = require('./util/syntaxKind');
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'pipe-impure',
+    type: 'functionality',
+    description: `Pipes cannot be declared as impure.`,
+    rationale: `Impure pipes do not perform well because they are run on every change detection cycle.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE: string = 'Warning: impure pipe declared in class %s.';
 
   public apply(sourceFile:ts.SourceFile):Lint.RuleFailure[] {

--- a/src/pipeNamingRule.ts
+++ b/src/pipeNamingRule.ts
@@ -6,6 +6,31 @@ import {Ng2Walker} from './angular/ng2Walker';
 import {SelectorValidator} from './util/selectorValidator';
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'pipe-naming-rule',
+    type: 'style',
+    description: `Enforce consistent case and prefix for pipes.`,
+    rationale: `Consistent conventions make it easy to quickly identify and reference assets of different types.`,
+    options: {
+      "type": "array",
+      "items": [
+        {"enum": ["kebab-case", "attribute"]},
+        {"type": "string"}
+      ],
+      "minItems": 1
+    },
+    optionExamples: [
+      `["camelCase", "myPrefix"]`,
+      `["camelCase", "myPrefix", "myOtherPrefix"]`,
+      `["kebab-case", "my-prefix"]`,
+    ],
+    optionsDescription: Lint.Utils.dedent`
+    * The first item in the array is \`"kebab-case"\` or \`"camelCase"\`, which allows you to pick a case.
+    * The rest of the arguments are supported prefixes (given as strings). They are optional.`,
+    typescriptOnly: true,
+  };
+
+
   static  FAILURE_WITHOUT_PREFIX: string = 'The name of the Pipe decorator of class %s should' +
     ' be named camelCase, however its value is "%s".';
 

--- a/src/templatesUsePublicRule.ts
+++ b/src/templatesUsePublicRule.ts
@@ -74,6 +74,16 @@ class SymbolAccessValidator extends RecursiveAngularExpressionVisitor {
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'templates-use-public-rule',
+    type: 'functionality',
+    description: `Ensure that properties and methods accessed from the template are public.`,
+    rationale: `When Angular compiles the templates, it has to access these propertes from outside the class.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
   static FAILURE: string = 'The %s "%s" that you\'re trying to access does not exist in the class declaration.';
 
   public apply(sourceFile:ts.SourceFile): Lint.RuleFailure[] {

--- a/src/useHostPropertyDecoratorRule.ts
+++ b/src/useHostPropertyDecoratorRule.ts
@@ -3,6 +3,20 @@ import * as Lint from 'tslint';
 import {UsePropertyDecorator} from './propertyDecoratorBase';
 
 export class Rule extends UsePropertyDecorator {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'use-host-property-decorator-rule',
+    type: 'style',
+    description: `Use @HostProperty decorator rather than the \`host\` property of \`@Component\` and \`@Directive\` metadata.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#06-03.`,
+    rationale: `The property associated with \`@HostBinding\` or the method associated with \`@HostListener\` ` +
+    `can be modified only in a single place: in the directive's class. If you use the \`host\` metadata ` +
+    `property, you must modify both the property declaration inside the controller, and the metadata ` +
+    `associated with the directive.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
   constructor(ruleName: string, value: any, disabledIntervals: Lint.IDisabledInterval[]) {
     super({
       decoratorName: ['HostBindings', 'HostListeners'],

--- a/src/useInputPropertyDecoratorRule.ts
+++ b/src/useInputPropertyDecoratorRule.ts
@@ -3,6 +3,22 @@ import * as Lint from 'tslint';
 import {UsePropertyDecorator} from './propertyDecoratorBase';
 
 export class Rule extends UsePropertyDecorator {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'use-input-property-decorator-rule',
+    type: 'style',
+    description: `Use \`@Input\` decorator rather than the \`inputs\` property of \`@Component\` and \`@Directive\` metadata.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#05-12.`,
+    rationale: Lint.Utils.dedent`
+    * It is easier and more readable to identify which properties in a class are inputs.
+    * If you ever need to rename the property name associated with \`@Input\`, you can modify it in a single place.
+    * The metadata declaration attached to the directive is shorter and thus more readable.
+    * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an input.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   constructor(ruleName: string, value: any, disabledIntervals: Lint.IDisabledInterval[]) {
     super({
       decoratorName: 'Input',

--- a/src/useLifeCycleInterfaceRule.ts
+++ b/src/useLifeCycleInterfaceRule.ts
@@ -11,6 +11,16 @@ const getInterfaceName = (t: any) => {
 };
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'use-life-cycle-interface',
+    type: 'maintainability',
+    description: `Ensure that components implement life cycle interfaces if they use them.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#09-01.`,
+    rationale: `Interfaces prescribe typed method signatures. Use those signatures to flag spelling and syntax mistakes.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
 
   static FAILURE:string = 'Implement lifecycle hook interface %s for method %s in class %s ($$09-01$$)';
 

--- a/src/useOutputPropertyDecoratorRule.ts
+++ b/src/useOutputPropertyDecoratorRule.ts
@@ -3,6 +3,22 @@ import * as Lint from 'tslint';
 import {UsePropertyDecorator} from './propertyDecoratorBase';
 
 export class Rule extends UsePropertyDecorator {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'use-output-property-decorator-rule',
+    type: 'style',
+    description: `Use \`@Output\` decorator rather than the \`outputs\` property of \`@Component\` and \`@Directive\` metadata.`,
+    descriptionDetails: `See more at https://angular.io/styleguide#!#05-12.`,
+    rationale: Lint.Utils.dedent`
+    * It is easier and more readable to identify which properties in a class are events.
+    * If you ever need to rename the event name associated with \`@Output\`, you can modify it in a single place.
+    * The metadata declaration attached to the directive is shorter and thus more readable.
+    * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an output.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   constructor(ruleName: string, value: any, disabledIntervals: Lint.IDisabledInterval[]) {
     super({
       decoratorName: 'Output',

--- a/src/usePipeTransformInterfaceRule.ts
+++ b/src/usePipeTransformInterfaceRule.ts
@@ -11,6 +11,17 @@ const getInterfaceName = (t: any) => {
 };
 
 export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'use-pipe-transform-interface',
+    type: 'maintainability',
+    description: `Ensure that pipes implement PipeTransform interface.`,
+    rationale: `Interfaces prescribe typed method signatures. Use those signatures to flag spelling and syntax mistakes.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+
   static FAILURE: string = 'The %s class has the Pipe decorator, so it should implement the PipeTransform interface';
   static PIPE_INTERFACE_NAME = 'PipeTransform';
 


### PR DESCRIPTION
I realized too late that some of the rules are not in v3 anymore, but oh well. I tried quoting the official styleguide whenever it made sense in the context.

I've seen `Lint.Utils.dedent` in tslint source code so no idea how exactly it works, but we'll see after building the docs page and change it accordingly later, I guess.