### PR TITLE
test(*): support multiple annotated failures

### DIFF
--- a/test/componentSelectorRule.spec.ts
+++ b/test/componentSelectorRule.spec.ts
@@ -1,4 +1,4 @@
-import { assertSuccess, assertAnnotated} from './testHelper';
+import {assertSuccess, assertAnnotated, assertMultipleAnnotated} from './testHelper';
 
 describe('component-selector-prefix', () => {
     describe('invalid component selectors', () => {
@@ -49,14 +49,17 @@ describe('component-selector-prefix', () => {
 
         it('should fail when component used longer prefix', () => {
             let source = `
-          @Component({
-            selector: 'foo-bar'
-                      ~~~~~~~~~
-          })
-      class Test {}`;
-            assertAnnotated({
+          @Component({selector: 'foo-bar'}) class TestOne {} 
+                                ~~~~~~~~~
+          @Component({selector: 'ngg-bar'}) class TestTwo {}
+                                ^^^^^^^^^
+          `;
+            assertMultipleAnnotated({
                 ruleName: 'component-selector',
-                message:  'The selector of the component "Test" should have one of the prefixes: fo,mg,ng ($$02-07$$)',
+                failures: [
+                  { char: '~', msg: 'The selector of the component "TestOne" should have one of the prefixes: fo,mg,ng ($$02-07$$)'},
+                  { char: '^', msg: 'The selector of the component "TestTwo" should have one of the prefixes: fo,mg,ng ($$02-07$$)'},
+                ],
                 source,
                 options: ['element', ['fo','mg','ng'], 'kebab-case']
             });


### PR DESCRIPTION
The [way `tslint` does it](https://github.com/palantir/tslint/blob/master/test/rules/jsdoc-format/jsdoc.js.lint) seems like an overkill and is actually less readable for our small tests (too much clutter). It looks much clearer to me like this. We can add the `[failure]` syntax when we feel the need for it. There are enough symbols like this; it basically it just has to be a symbol which is not otherwise used in the snippet.

I updated a (kinda) random test to test the new helper function, although it doesn't make _that_ much sense to test two same error messages (I couldn't find an existing rule on master branch in which two different error messages can happen in the same context).