### PR TITLE
feat: add a no-negated-async rule

### DIFF
--- a/src/templatesNoNegatedAsyncRule.ts
+++ b/src/templatesNoNegatedAsyncRule.ts
@@ -5,32 +5,55 @@ import {RecursiveAngularExpressionVisitor} from './angular/templates/recursiveAn
 import * as e from '@angular/compiler/src/expression_parser/ast';
 import * as ast from '@angular/compiler';
 
+const unstrictEqualityOperator = '==';
+
 class TemplateToNgTemplateVisitor extends RecursiveAngularExpressionVisitor {
   visitBinary(expr: e.Binary, context: any): any {
     if (!this.isAsyncBinding(expr.left)) {
       return super.visitBinary(expr, context);
     }
-    if (!(expr.right instanceof ast.LiteralPrimitive) || expr.right.value !== false || expr.operation !== '==') {
+    if (!(expr.right instanceof ast.LiteralPrimitive) || expr.right.value !== false || expr.operation !== unstrictEqualityOperator) {
       return super.visitBinary(expr, context);
     }
+
+    const operator = this.codeWithMap.code.slice(expr.left.span.end, expr.right.span.start);
+    const operatorStart = (/^.*==/).exec(operator)[0].length - unstrictEqualityOperator.length;
 
     this.addFailure(this.createFailure(
       expr.span.start,
       expr.span.end - expr.span.start,
       `Async pipes must use strict equality \`===\` when comparing with \`false\``,
+      [
+        new Lint.Replacement(
+          this.getSourcePosition(expr.left.span.end) + operatorStart,
+          unstrictEqualityOperator.length,
+          '===',
+        ),
+      ]
     ));
   }
 
   visitPrefixNot(expr: e.PrefixNot, context: any): any {
-    if (this.isAsyncBinding(expr.expression)) {
-      this.addFailure(this.createFailure(
-        expr.span.start,
-        expr.span.end - expr.span.start,
-        `Async pipes can not be negated, use (observable | async) === false instead`,
-      ));
-    } else {
-      super.visitPrefixNot(expr, context);
+    if (!this.isAsyncBinding(expr.expression)) {
+      return super.visitPrefixNot(expr, context);
     }
+
+    const width = expr.span.end - expr.span.start;
+    const absoluteStart = this.getSourcePosition(expr.span.start);
+
+    // Angular includes the whitespace after an expression, we want to trim that
+    const expressionSource = this.codeWithMap.code.slice(expr.span.start, expr.span.end);
+    const concreteWidth = width - (/ *$/).exec(expressionSource)[0].length;
+
+    this.addFailure(this.createFailure(
+      expr.span.start,
+      width,
+      `Async pipes can not be negated, use (observable | async) === false instead`,
+      [
+        new Lint.Replacement(absoluteStart + concreteWidth, 1, ' === false '),
+        new Lint.Replacement(absoluteStart, 1, ''),
+      ],
+    ));
   }
 
   protected isAsyncBinding(expr: any) {

--- a/src/templatesNoNegatedAsyncRule.ts
+++ b/src/templatesNoNegatedAsyncRule.ts
@@ -1,0 +1,59 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import {NgWalker} from './angular/ngWalker';
+import {RecursiveAngularExpressionVisitor} from './angular/templates/recursiveAngularExpressionVisitor';
+import * as e from '@angular/compiler/src/expression_parser/ast';
+import * as ast from '@angular/compiler';
+
+class TemplateToNgTemplateVisitor extends RecursiveAngularExpressionVisitor {
+  visitBinary(expr: e.Binary, context: any): any {
+    if (!this.isAsyncBinding(expr.left)) {
+      return super.visitBinary(expr, context);
+    }
+    if (!(expr.right instanceof ast.LiteralPrimitive) || expr.right.value !== false || expr.operation !== '==') {
+      return super.visitBinary(expr, context);
+    }
+
+    this.addFailure(this.createFailure(
+      expr.span.start,
+      expr.span.end - expr.span.start,
+      `Async pipes must use strict equality \`===\` when comparing with \`false\``,
+    ));
+  }
+
+  visitPrefixNot(expr: e.PrefixNot, context: any): any {
+    if (this.isAsyncBinding(expr.expression)) {
+      this.addFailure(this.createFailure(
+        expr.span.start,
+        expr.span.end - expr.span.start,
+        `Async pipes can not be negated, use (observable | async) === false instead`,
+      ));
+    } else {
+      super.visitPrefixNot(expr, context);
+    }
+  }
+
+  protected isAsyncBinding(expr: any) {
+    return expr instanceof ast.BindingPipe && expr.name === 'async';
+  }
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'templates-no-negated-async-rule',
+    type: 'functionality',
+    description: `Ensures that strict equality is used when evaluating negations on async pipe outout.`,
+    rationale: `Async pipe evaluate to \`null\` before the observable or promise emits, which can lead to layout thrashing as components load. Prefer strict \`=== false\` checks instead.`,
+    options: null,
+    optionsDescription: `Not configurable.`,
+    typescriptOnly: true,
+  };
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(
+        new NgWalker(sourceFile,
+            this.getOptions(), {
+              expressionVisitorCtrl: TemplateToNgTemplateVisitor
+            }));
+  }
+}

--- a/test/templatesNoNegatedAsyncRule.spec.ts
+++ b/test/templatesNoNegatedAsyncRule.spec.ts
@@ -1,0 +1,106 @@
+import { assertSuccess, assertAnnotated } from './testHelper';
+
+describe('templates-no-negated-async', () => {
+  describe('invalid expressions', () => {
+    it('should fail when an async pipe is negated', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ !(foo | async) }}'
+                        ~~~~~~~~~~~~~~~
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertAnnotated({
+          ruleName: 'templates-no-negated-async',
+          message: 'Async pipes can not be negated, use (observable | async) === false instead',
+          source
+        });
+    });
+
+    it('should fail when an async pipe is including other pipes', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ !(foo | somethingElse | async) }}'
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertAnnotated({
+          ruleName: 'templates-no-negated-async',
+          message: 'Async pipes can not be negated, use (observable | async) === false instead',
+          source
+        });
+    });
+
+    it('should fail when an async pipe uses non-strict equality', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ (foo | async) == false }}'
+                         ~~~~~~~~~~~~~~~~~~~~~~
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertAnnotated({
+          ruleName: 'templates-no-negated-async',
+          message: 'Async pipes must use strict equality `===` when comparing with `false`',
+          source
+        });
+    });
+  });
+
+  describe('valid expressions', () => {
+    it('should succeed if an async pipe is not negated', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ (foo | async) }}'
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertSuccess('templates-no-negated-async', source);
+    });
+
+    it('should succeed if an async pipe is not the last pipe in the negated chain', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ !(foo | async | someOtherFilter) }}'
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertSuccess('templates-no-negated-async', source);
+    });
+
+    it('should succeed if an async pipe uses strict equality', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ (foo | async) === false }}'
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertSuccess('templates-no-negated-async', source);
+    });
+
+    it('should succeed if any other pipe is negated', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ !(foo | notAnAsyncPipe) }}'
+        })
+        class Test {
+          constructor(public foo: Observable<Boolean>) {}
+        }`;
+        assertSuccess('templates-no-negated-async', source);
+    });
+  });
+});

--- a/test/templatesNoNegatedAsyncRule.spec.ts
+++ b/test/templatesNoNegatedAsyncRule.spec.ts
@@ -1,4 +1,6 @@
 import { assertSuccess, assertAnnotated } from './testHelper';
+import { Replacement } from 'tslint';
+import { expect } from 'chai';
 
 describe('templates-no-negated-async', () => {
   describe('invalid expressions', () => {
@@ -38,19 +40,69 @@ describe('templates-no-negated-async', () => {
 
     it('should fail when an async pipe uses non-strict equality', () => {
       let source = `
+      @Component({
+        selector: 'foobar',
+        template: '{{ (foo | async) == false }}'
+                       ~~~~~~~~~~~~~~~~~~~~~~
+      })
+      class Test {
+        constructor(public foo: Observable<Boolean>) {}
+      }`;
+      assertAnnotated({
+        ruleName: 'templates-no-negated-async',
+        message: 'Async pipes must use strict equality `===` when comparing with `false`',
+        source
+      });
+    });
+
+    describe('fixes', () => {
+      it('fixes negated pipes', () => {
+        let source = `
+        @Component({
+          selector: 'foobar',
+          template: '{{ !(foo | async) }}'
+                        ~~~~~~~~~~~~~~~
+        })
+        class Test {}`;
+        const failures =  assertAnnotated({
+          ruleName: 'templates-no-negated-async',
+          message: 'Async pipes can not be negated, use (observable | async) === false instead',
+          source
+        });
+
+        const res = Replacement.applyAll(source, failures[0].getFix());
+        expect(res).to.eq(`
+        @Component({
+          selector: 'foobar',
+          template: '{{ (foo | async) === false }}'
+                        ~~~~~~~~~~~~~~~
+        })
+        class Test {}`);
+      });
+
+      it('fixes un-strict equality', () => {
+        let source = `
         @Component({
           selector: 'foobar',
           template: '{{ (foo | async) == false }}'
                          ~~~~~~~~~~~~~~~~~~~~~~
         })
-        class Test {
-          constructor(public foo: Observable<Boolean>) {}
-        }`;
-        assertAnnotated({
+        class Test {}`;
+        const failures =  assertAnnotated({
           ruleName: 'templates-no-negated-async',
           message: 'Async pipes must use strict equality `===` when comparing with `false`',
           source
         });
+
+        const res = Replacement.applyAll(source, failures[0].getFix());
+        expect(res).to.eq(`
+        @Component({
+          selector: 'foobar',
+          template: '{{ (foo | async) === false }}'
+                         ~~~~~~~~~~~~~~~~~~~~~~
+        })
+        class Test {}`);
+      });
     });
   });
 


### PR DESCRIPTION
Angular's async pipes emit `null` initially, prior to the observable emitting
any values, or the promise resolving. This can cause negations, like
`*ngIf="!(myConditional | async)"` to thrash the layout and cause expensive
side-effects like firing off XHR requests for a component which should not
be shown.

This PR adds a linting rule which fails on usages of !(expr | async) and
(expr | async) == false.