### PR TITLE
test: add failing test for check-pipe in ngFor with external template

### DIFF
--- a/test/angularWhitespaceRule.spec.ts
+++ b/test/angularWhitespaceRule.spec.ts
@@ -138,6 +138,22 @@ describe('angular-whitespace', () => {
         assertSuccess('angular-whitespace', source, ['check-pipe']);
       });
 
+      it('should work with external templates with ngFor', () => {
+        const code = `
+        @Component({
+          selector: 'foo',
+          moduleId: module.id,
+          templateUrl: 'ngFor.html',
+        })
+        class Bar {
+          ponies = []
+        }
+        `;
+        const reader = new MetadataReader(new FsFileResolver());
+        const ast = getAst(code, __dirname + '/../../test/fixtures/angularWhitespace/component.ts');
+        assertSuccess('angular-whitespace', ast, ['check-pipe']);
+      });
+
       it('should succeed with i18n and description', () => {
         let source = `
         @Component({
@@ -716,4 +732,3 @@ describe('pipes', () => {
       `);
   });
 });
-

--- a/test/fixtures/angularWhitespace/ngFor.html
+++ b/test/fixtures/angularWhitespace/ngFor.html
@@ -1,0 +1,3 @@
+<div *ngFor="let pony of ponies | slice:0:4">
+  <h2>{{ pony.name }}</h2>
+</div>


### PR DESCRIPTION
Adds a failing test to reproduce [#346](https://github.com/mgechev/codelyzer/issues/346 "check-pipe breaks with ngFor") with an external template.