### PR TITLE
fix: add i18n rule to npm package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {Rule as ContextualLifeCycleRule} from './contextualLifeCycleRule';
 export {Rule as DecoratorNotAllowedRule} from './decoratorNotAllowedRule';
 export {Rule as DirectiveClassSuffixRule} from './directiveClassSuffixRule';
 export {Rule as DirectiveSelectorRule} from './directiveSelectorRule';
+export {Rule as I18nRule} from './i18nRule';
 export {Rule as ImportDestructuringSpacingRule} from './importDestructuringSpacingRule';
 export {Rule as InvokeInjectableRule} from './invokeInjectableRule';
 export {Rule as NoAccessMissingMemberRule} from './noAccessMissingMemberRule';


### PR DESCRIPTION
Add the i18n rule to index.ts so that it is included in the npm package.

Fix #433