### PR TITLE
fix: directive config for material2 beta.12

### DIFF
--- a/src/angular/config.ts
+++ b/src/angular/config.ts
@@ -66,15 +66,24 @@ export const Config: Config = {
     { selector: 'form:not([ngNoForm]):not([formGroup]), ngForm, [ngForm]', exportAs: 'ngForm' },
     { selector: '[routerLinkActive]', exportAs: 'routerLinkActive' },
     { selector: '[ngModel]:not([formControlName]):not([formControl])', exportAs: 'ngModel' },
-    { selector: '[md-menu-item], [mat-menu-item]', exportAs: 'mdMenuItem' },
-    { selector: 'md-menu, mat-menu', exportAs: 'mdMenu' },
-    { selector: 'md-button-toggle-group:not([multiple])', exportAs: 'mdButtonToggleGroup' },
-    { selector: '[md-menu-trigger-for], [mat-menu-trigger-for], [mdMenuTriggerFor]', exportAs: 'mdMenuTrigger' },
-    { selector: '[md-tooltip], [mat-tooltip], [mdTooltip]', exportAs: 'mdTooltip' },
-    { selector: 'md-select, mat-select', exportAs: 'mdSelect' },
     { selector: '[ngIf]', exportAs: 'ngIf', inputs: ['ngIf'] },
     { selector: '[ngFor][ngForOf]', exportAs: 'ngFor', inputs: ['ngForTemplate', 'ngForOf'] },
-    { selector: '[ngSwitch]', exportAs: 'ngSwitch', inputs: ['ngSwitch'] }
+    { selector: '[ngSwitch]', exportAs: 'ngSwitch', inputs: ['ngSwitch'] },
+
+    // @angular/material
+    { selector: '[mat-menu-item]', exportAs: 'matMenuItem' },
+    { selector: 'mat-menu', exportAs: 'matMenu' },
+    { selector: 'mat-button-toggle-group:not([multiple])', exportAs: 'matButtonToggleGroup' },
+    { selector: '[mat-menu-trigger-for], [matMenuTriggerFor]', exportAs: 'matMenuTrigger' },
+    { selector: '[mat-tooltip], [matTooltip]', exportAs: 'matTooltip' },
+    { selector: 'mat-select', exportAs: 'matSelect' },
+    // The `md-` prefix is deprecated since beta.11, removed since beta.12
+    { selector: '[md-menu-item]', exportAs: 'mdMenuItem' },
+    { selector: 'md-menu', exportAs: 'mdMenu' },
+    { selector: 'md-button-toggle-group:not([multiple])', exportAs: 'mdButtonToggleGroup' },
+    { selector: '[md-menu-trigger-for], [mdMenuTriggerFor]', exportAs: 'mdMenuTrigger' },
+    { selector: '[md-tooltip], [mdTooltip]', exportAs: 'mdTooltip' },
+    { selector: 'md-select', exportAs: 'mdSelect' }
   ],
 
   logLevel: BUILD_TYPE === 'dev' ? LogLevel.Debug : LogLevel.None

--- a/test/noAccessMissingMemberRule.spec.ts
+++ b/test/noAccessMissingMemberRule.spec.ts
@@ -261,6 +261,70 @@ describe('no-access-missing-member', () => {
         assertSuccess('no-access-missing-member', source);
     });
 
+    it('should not throw when [mat-menu-item] template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<div mat-menu-item #test="matMenuItem">{{ test }}</div>'
+        })
+        class Test {
+          foo: string;
+        }`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should not throw when mat-menu template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<mat-menu #test="matMenu">{{ test }}</mat-menu>'
+        })
+        class Test {
+          foo: string;
+        }`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should not throw when mat-button-toggle-group template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<mat-button-toggle-group #test="matButtonToggleGroup">{{ test }}</mat-button-toggle-group>'
+        })
+        class Test {}`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should not throw when mat-menu-trigger-for template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<div matMenuTriggerFor #test="matMenuTrigger">{{ test }}</div>'
+        })
+        class Test {}`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should not throw when matTooltip template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<div matTooltip #test="matTooltip">{{ test }}</div>'
+        })
+        class Test {}`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
+    it('should not throw when matSelect template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<mat-select #test="matSelect">{{ test }}</mat-select>'
+        })
+        class Test {}`;
+        assertSuccess('no-access-missing-member', source);
+    });
+
     it('should not throw when [md-menu-item] template ref is used in component', () => {
       let source = `
         @Component({


### PR DESCRIPTION
Related to #437

I noticed that there seem to be a lot of directives that has exports that are not configured (e.g. `mat-button` with `matButton` export). But I deemed it out of scope here, I just added the equivalent `mat` selectors and exports for the existing directives.

I also had trouble running tests on windows (there is no `cp` command), so I'll just hope it passes on the CI.