### PR TITLE
fix: added support for mat-autocomplete

### DIFF
--- a/src/angular/config.ts
+++ b/src/angular/config.ts
@@ -71,6 +71,7 @@ export const Config: Config = {
     { selector: '[ngSwitch]', exportAs: 'ngSwitch', inputs: ['ngSwitch'] },
 
     // @angular/material
+    { selector: 'mat-autocomplete', exportAs: 'matAutocomplete' },
     { selector: '[mat-menu-item]', exportAs: 'matMenuItem' },
     { selector: 'mat-menu', exportAs: 'matMenu' },
     { selector: 'mat-button-toggle-group:not([multiple])', exportAs: 'matButtonToggleGroup' },

--- a/test/noAccessMissingMemberRule.spec.ts
+++ b/test/noAccessMissingMemberRule.spec.ts
@@ -261,6 +261,16 @@ describe('no-access-missing-member', () => {
         assertSuccess('no-access-missing-member', source);
     });
 
+    it('should not throw when mat-autocomplete template ref is used in component', () => {
+      let source = `
+        @Component({
+          selector: 'foobar',
+          template: '<mat-autocomplete #test="matAutocomplete">{{ test }}</mat-autocomplete>'
+        })
+        class Test {}`;
+      assertSuccess('no-access-missing-member', source);
+    });
+
     it('should not throw when [mat-menu-item] template ref is used in component', () => {
       let source = `
         @Component({


### PR DESCRIPTION
Fixes linting error *"The property "foo" that you're trying to access does not exist in the class declaration"* for the following template example:

```
<input type="text" [matAutocomplete]="foo">
<mat-autocomplete #foo="matAutocomplete">
  <mat-option *ngFor="let v of values" [value]="v">{{ v }}</mat-option>
</mat-autocomplete>
```

I only added the fix for the new `mat-` prefixed version, due to the other being deprecated. But if preferred I can add it with `md` prefix too.