### PR TITLE
check multiple semicolons inside the directive expressions

### DIFF
--- a/src/angularWhitespaceRule.ts
+++ b/src/angularWhitespaceRule.ts
@@ -7,20 +7,80 @@ import { ExpTypes } from './angular/expressionTypes';
 import { Config } from './angular/config';
 import { RecursiveAngularExpressionVisitor } from './angular/templates/recursiveAngularExpressionVisitor';
 
+// Check if ES6 'y' flag is usable.
+const stickyFlagUsable = (() => {
+  try {
+    const reg = new RegExp('\d', 'y');
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();
+
 const InterpolationOpen = Config.interpolation[0];
 const InterpolationClose = Config.interpolation[1];
 const InterpolationWhitespaceRe = new RegExp(`${InterpolationOpen}(\\s*)(.*?)(\\s*)${InterpolationClose}`, 'g');
-const SemicolonNoWhitespaceNotInSimpleQuoteRe = new RegExp(/;\S(?![^']*')/);
-const SemicolonNoWhitespaceNotInDoubleQuoteRe = new RegExp(/;\S(?![^"]*")/);
+const SemicolonNoWhitespaceNotInSimpleQuoteRe = stickyFlagUsable ?
+  new RegExp(`(?:[^';]|'[^']*'|;(?=\\s))+;(?=\\S)`, 'gy') : /(?:[^';]|'[^']*')+;/g;
+const SemicolonNoWhitespaceNotInDoubleQuoteRe = stickyFlagUsable ?
+  new RegExp(`(?:[^";]|"[^"]*"|;(?=\\s))+;(?=\\S)`, 'gy') : /(?:[^";]|"[^"]*")+;/g;
 
 
-const getSemicolonReplacements = (text: ast.BoundDirectivePropertyAst, absolutePosition: number) => {
+const getSemicolonReplacements = (absolutePosition: number) => {
 
   return [
     new Lint.Replacement(absolutePosition, 1, '; ')
   ];
 
 };
+
+interface CheckSemicolonNoWhitespaceMethod {
+  (reg: RegExp, context: BasicTemplateAstVisitor, expr: string, fixedOffset: number): void;
+}
+
+// Simplify the code when the 'y' flag of RegExp is usable.
+const checkSemicolonNoWhitespaceWithSticky: CheckSemicolonNoWhitespaceMethod = (reg, context, expr, fixedOffset) => {
+  const error = 'Missing whitespace after semicolon; expecting \'; expr\'';
+  let exprMatch: RegExpExecArray | null;
+
+  while (exprMatch = reg.exec(expr)) {
+    const start = fixedOffset + reg.lastIndex;
+    const absolutePosition = context.getSourcePosition(start - 1);
+    context.addFailure(context.createFailure(start, 2,
+      error, getSemicolonReplacements(absolutePosition))
+    );
+  }
+};
+
+const checkSemicolonNoWhitespaceWithoutSticky: CheckSemicolonNoWhitespaceMethod = (reg, context, expr, fixedOffset) => {
+  const error = 'Missing whitespace after semicolon; expecting \'; expr\'';
+  let lastIndex = 0;
+  let exprMatch: RegExpExecArray | null;
+
+  while (exprMatch = reg.exec(expr)) {
+    // When the 'y' flag of RegExp is unusable, must compare lastIndex with match.index,
+    // otherwise the match results may be incorrect.
+    if (lastIndex !== exprMatch.index) {
+      break;
+    }
+
+    const nextIndex = reg.lastIndex;
+    // Check if the character after the semicolon is not a whitespace.
+    if (nextIndex < expr.length && /\S/.test(expr[nextIndex])) {
+      const start = fixedOffset + nextIndex;
+      const absolutePosition = context.getSourcePosition(start - 1);
+      context.addFailure(context.createFailure(start, 2,
+        error, getSemicolonReplacements(absolutePosition))
+      );
+    }
+
+    lastIndex = nextIndex;
+  }
+};
+
+const checkSemicolonNoWhitespace: CheckSemicolonNoWhitespaceMethod = stickyFlagUsable ?
+  checkSemicolonNoWhitespaceWithSticky :
+  checkSemicolonNoWhitespaceWithoutSticky;
 
 type Option = 'check-interpolation' | 'check-pipe' | 'check-semicolon';
 
@@ -81,30 +141,13 @@ class SemicolonTemplateVisitor extends BasicTemplateAstVisitor implements Config
       const match = /^([^=]+=\s*)([^]*?)\s*$/.exec(directive);
       const rawExpression = match[2];
       const positionFix = match[1].length + 1;
-      const expr = rawExpression.substring(1, rawExpression.length - 1).trim();
-
-      const doubleQuote = rawExpression.substring(0, 1).indexOf('\"') === 0;
+      const expr = rawExpression.slice(1, -1).trim();
+      const doubleQuote = rawExpression[0] === '"';
 
       // Note that will not be reliable for different interpolation symbols
-      let error = null;
-
-      if (doubleQuote && SemicolonNoWhitespaceNotInSimpleQuoteRe.test(expr)) {
-        error = 'Missing whitespace after semicolon; expecting \'; expr\'';
-        const internalStart = expr.search(SemicolonNoWhitespaceNotInSimpleQuoteRe) + 1;
-        const start = prop.sourceSpan.start.offset + internalStart + positionFix;
-        const absolutePosition = context.getSourcePosition(start - 1);
-        return context.addFailure(context.createFailure(start, 2,
-          error, getSemicolonReplacements(prop, absolutePosition))
-        );
-      } else if (!doubleQuote && SemicolonNoWhitespaceNotInDoubleQuoteRe.test(expr)) {
-        error = 'Missing whitespace after semicolon; expecting \'; expr\'';
-        const internalStart = expr.search(SemicolonNoWhitespaceNotInDoubleQuoteRe) + 1;
-        const start = prop.sourceSpan.start.offset + internalStart + positionFix;
-        const absolutePosition = context.getSourcePosition(start - 1);
-        return context.addFailure(context.createFailure(start, 2,
-          error, getSemicolonReplacements(prop, absolutePosition))
-        );
-      }
+      let reg = doubleQuote ? SemicolonNoWhitespaceNotInSimpleQuoteRe : SemicolonNoWhitespaceNotInDoubleQuoteRe;
+      reg.lastIndex = 0;
+      checkSemicolonNoWhitespace(reg, context, expr, prop.sourceSpan.start.offset + positionFix);
     }
   }
 

--- a/test/angularWhitespaceRule.spec.ts
+++ b/test/angularWhitespaceRule.spec.ts
@@ -272,6 +272,18 @@ describe('angular-whitespace', () => {
         assertSuccess('angular-whitespace', source, ['check-semicolon']);
       });
 
+
+      it('should work with proper style of multiple semicolons', () => {
+        let source = `
+      @Component({
+        template: \` <div *ngIf='date | date:"fullDate"; let dateString; else errorDate;'>{{ dateString }}</div>
+          <ng-template #errorDate>error date!</ng-template>
+        \`
+      })
+      class Bar {}`;
+        assertSuccess('angular-whitespace', source, ['check-semicolon']);
+      });
+
     });
 
   });
@@ -638,6 +650,120 @@ describe('failure', () => {
           @Component({
             template: \` <div *ngFor="let item of list; trackBy item?.id; let $index=index">{{ item.title }}</div>
                                                       ~~
+            \`
+          })
+          class Bar {}`);
+      });
+
+      it('should fail and apply proper replacements with multiple failures of semicolon inside double quote', () => {
+        let source = `
+          @Component({
+            template: \` <div *ngIf="date | date:'fullDate';let dateString;else errorDate">{{ dateString }}</div>
+                                                           ~~             ^^
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`;
+        const failures = assertMultipleAnnotated({
+          ruleName: 'angular-whitespace',
+          failures: [
+            {char: '~', msg: 'Missing whitespace after semicolon; expecting \'; expr\'', },
+            {char: '^', msg: 'Missing whitespace after semicolon; expecting \'; expr\'', },
+          ],
+          source,
+          options: ['check-semicolon']
+        });
+
+        const res = Replacement.applyAll(source, [].concat.apply([], failures.map(f => f.getFix())));
+        expect(res).to.eq(`
+          @Component({
+            template: \` <div *ngIf="date | date:'fullDate'; let dateString; else errorDate">{{ dateString }}</div>
+                                                           ~~             ^^
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`);
+      });
+
+      it('should fail and apply proper replacements with multiple failures of semicolon inside single quote', () => {
+        let source = `
+          @Component({
+            template: \` <div *ngIf='date | date:"fullDate";let dateString;else errorDate'>{{ dateString }}</div>
+                                                           ~~             ^^
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`;
+        const failures = assertMultipleAnnotated({
+          ruleName: 'angular-whitespace',
+          failures: [
+            {char: '~', msg: 'Missing whitespace after semicolon; expecting \'; expr\'', },
+            {char: '^', msg: 'Missing whitespace after semicolon; expecting \'; expr\'', },
+          ],
+          source,
+          options: ['check-semicolon']
+        });
+
+        const res = Replacement.applyAll(source, [].concat.apply([], failures.map(f => f.getFix())));
+        expect(res).to.eq(`
+          @Component({
+            template: \` <div *ngIf='date | date:"fullDate"; let dateString; else errorDate'>{{ dateString }}</div>
+                                                           ~~             ^^
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`);
+      });
+
+      it('should fail and apply proper replacement with single failure of multiple semicolons inside double quote', () => {
+        let source = `
+          @Component({
+            template: \` <div *ngIf="date | date:'fullDate'; let dateString;else errorDate;">{{ dateString }}</div>
+                                                                           ~~
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`;
+        const failures = assertAnnotated({
+          ruleName: 'angular-whitespace',
+          message: 'Missing whitespace after semicolon; expecting \'; expr\'',
+          source,
+          options: ['check-semicolon']
+        });
+
+        const res = Replacement.applyAll(source, failures[0].getFix());
+        expect(res).to.eq(`
+          @Component({
+            template: \` <div *ngIf="date | date:'fullDate'; let dateString; else errorDate;">{{ dateString }}</div>
+                                                                           ~~
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`);
+      });
+
+      it('should fail and apply proper replacement with single failure of multiple semicolons inside single quote', () => {
+        let source = `
+          @Component({
+            template: \` <div *ngIf='date | date:"fullDate"; let dateString;else errorDate;'>{{ dateString }}</div>
+                                                                           ~~
+              <ng-template #errorDate>error date!</ng-template>
+            \`
+          })
+          class Bar {}`;
+        const failures = assertAnnotated({
+          ruleName: 'angular-whitespace',
+          message: 'Missing whitespace after semicolon; expecting \'; expr\'',
+          source,
+          options: ['check-semicolon']
+        });
+
+        const res = Replacement.applyAll(source, failures[0].getFix());
+        expect(res).to.eq(`
+          @Component({
+            template: \` <div *ngIf='date | date:"fullDate"; let dateString; else errorDate;'>{{ dateString }}</div>
+                                                                           ~~
+              <ng-template #errorDate>error date!</ng-template>
             \`
           })
           class Bar {}`);


### PR DESCRIPTION
**check multiple semicolons inside the directive expressions for angular-whitespace rule**

The `check-semicolon` rule of `angular-whitespace` could only check out and fix the first error when there are mutiple semicolon errors inside the directive expressions. For example:

```html
  <h3 *ngIf="date | date:'fullDate';let dateString;else errorDate">{{ dateString }}</h3>
  <ng-template #errorDate>error date!</ng-template>
```

Only the first error ( `;let` ) should be check out and fixed. If someone want to fix all of two errors of this example, it must run the `tslint --fix` command twice.

I have rewritten the codes of `check-semicolon` to solve the problem, also add 5 test cases, one for success check, and 4 for fail/apply proper replacements.