### PR TITLE
fix(no-output-on-prefix): do not warn on properly named props

### DIFF
--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -13,34 +13,29 @@ export class Rule extends Lint.Rules.AbstractRule {
      this would result in an on-onEvent binding expression`,
     options: null,
     optionsDescription: 'Not configurable.',
-    typescriptOnly: true,
+    typescriptOnly: true
   };
 
-  static FAILURE_STRING: string = 'In the class "%s", the output ' +
-    'property "%s" should not be prefixed with on';
+  static FAILURE_STRING: string = 'In the class "%s", the output ' + 'property "%s" should not be prefixed with on';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(
-      new OutputWalker(sourceFile,
-        this.getOptions()));
+    return this.applyWithWalker(new OutputWalker(sourceFile, this.getOptions()));
   }
 }
 
 class OutputWalker extends NgWalker {
   visitNgOutput(property: ts.PropertyDeclaration, output: ts.Decorator, args: string[]) {
     const className = (<any>property).parent.name.text;
-    const memberName = (<any>property.name).text;
+    const memberName = (<any>property.name).text as string;
 
-    if (memberName && memberName.startsWith('on')) {
+    if (
+      memberName &&
+      memberName.startsWith('on') &&
+      !(memberName.length >= 3 && memberName[2] !== memberName[2].toUpperCase())
+    ) {
       const failureConfig: string[] = [Rule.FAILURE_STRING, className, memberName];
       const errorMessage = sprintf.apply(null, failureConfig);
-      this.addFailure(
-        this.createFailure(
-          property.getStart(),
-          property.getWidth(),
-          errorMessage
-        )
-      );
+      this.addFailure(this.createFailure(property.getStart(), property.getWidth(), errorMessage));
     }
   }
 }

--- a/test/noOutputOnPrefixRule.spec.ts
+++ b/test/noOutputOnPrefixRule.spec.ts
@@ -30,6 +30,19 @@ describe('no-output-on-prefix', () => {
       });
     });
 
+    it('should fail, when a directive output property is named with on prefix', () => {
+      const source = `
+      @Directive()
+      class ButtonDirective {
+        @Output() on = new EventEmitter<any>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-output-on-prefix',
+        message: 'In the class "ButtonDirective", the output property "on" should not be prefixed with on',
+        source
+      });
+    });
   });
 
   describe('valid directive output property', () => {
@@ -38,6 +51,15 @@ describe('no-output-on-prefix', () => {
       @Component()
       class ButtonComponent {
          @Output() change = new EventEmitter<any>();
+      }`;
+      assertSuccess('no-output-on-prefix', source);
+    });
+
+    it('should succeed, when a directive output property is properly named, starting with `on`', () => {
+      const source = `
+      @Component()
+      class ButtonComponent {
+         @Output() oneProp = new EventEmitter<any>();
       }`;
       assertSuccess('no-output-on-prefix', source);
     });


### PR DESCRIPTION
Fix #480