### PR TITLE
fix(trackBy): fix rule when ngFor statements include let assignments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -666,6 +666,21 @@
         "globule": "1.2.0"
       }
     },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -896,6 +911,24 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -997,6 +1030,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
@@ -1126,6 +1165,12 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1291,9 +1336,9 @@
       }
     },
     "node-sass": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
-      "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
+      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -1305,13 +1350,76 @@
         "in-publish": "2.0.0",
         "lodash.assign": "4.2.0",
         "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.0",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
         "nan": "2.6.2",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.81.0",
-        "sass-graph": "2.2.4"
+        "request": "2.79.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.9.0",
+            "is-my-json-valid": "2.17.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.16",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true
+        }
       }
     },
     "nopt": {
@@ -1794,6 +1902,15 @@
         }
       }
     },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1892,6 +2009,30 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "dev": true,
+      "requires": {
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
     },
     "ts-node": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chai-spies": "^0.7.1",
     "minimalist": "1.0.0",
     "mocha": "3.0.2",
-    "node-sass": "^3.13.0",
+    "node-sass": "^4.7.2",
     "rimraf": "^2.5.2",
     "rxjs": "^5.5.0",
     "ts-node": "1.2.2",

--- a/src/trackByFunctionRule.ts
+++ b/src/trackByFunctionRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-const ngForExpressionRe = new RegExp(/\*ngFor="(.+)"/);
+const ngForExpressionRe = new RegExp(/\*ngFor\s*=\s*(?:'|")(.+)(?:'|")/);
 const trackByRe = new RegExp(/trackBy\s*:/);
 
 class TrackByNgForTemplateVisitor extends BasicTemplateAstVisitor {

--- a/src/trackByFunctionRule.ts
+++ b/src/trackByFunctionRule.ts
@@ -24,28 +24,26 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
+const ngForExpressionRe = new RegExp(/\*ngFor="(.+)"/);
 const trackByRe = new RegExp(/trackBy\s*:/);
 
 class TrackByNgForTemplateVisitor extends BasicTemplateAstVisitor {
-
   static Error = 'Missing trackBy function in ngFor directive';
 
   visitDirectiveProperty(prop: ast.BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
-
     if (prop.sourceSpan) {
       const directive = (<any>prop.sourceSpan).toString();
-      const rawExpression = directive.split('=')[1].trim();
-      const expr = rawExpression.substring(1, rawExpression.length - 1).trim();
 
-      if (directive.startsWith('*ngFor') && !trackByRe.test(expr)) {
-        const span = prop.sourceSpan;
-        context.addFailure(
-          context.createFailure(
-            span.start.offset,
-            span.end.offset - span.start.offset,
-            TrackByNgForTemplateVisitor.Error
-          )
-        );
+      if (directive.startsWith('*ngFor')) {
+        const directiveMatch = directive.match(ngForExpressionRe);
+        const expr = directiveMatch && directiveMatch[1];
+
+        if (expr && !trackByRe.test(expr)) {
+          const span = prop.sourceSpan;
+          context.addFailure(
+            context.createFailure(span.start.offset, span.end.offset - span.start.offset, TrackByNgForTemplateVisitor.Error)
+          );
+        }
       }
     }
     super.visitDirectiveProperty(prop, context);

--- a/test/trackByRule.spec.ts
+++ b/test/trackByRule.spec.ts
@@ -53,6 +53,37 @@ describe('trackBy-function', () => {
     });
   });
 
+  it('should have a trackBy function with different quotes', () => {
+    let source = `
+    @Component({
+      template: \`
+       <ul>
+          <li *ngFor='let person of persons; let i = index; trackBy: trackByFn'>
+           {{ person.name }}
+          </li>
+       </ul>
+       \`
+    })
+    class Bar {}
+    `;
+    assertSuccess('trackBy-function', source);
+  });
+
+  it('should have a trackBy function with different spacing', () => {
+    let source = `
+    @Component({
+      template: \`
+       <ul>
+          <li *ngFor  =  "let person of persons; let i = index; trackBy : trackByFn">
+           {{ person.name }}
+          </li>
+       </ul>
+       \`
+    })
+    class Bar {}
+    `;
+    assertSuccess('trackBy-function', source);
+  });
 
   describe('failure', () => {
 

--- a/test/trackByRule.spec.ts
+++ b/test/trackByRule.spec.ts
@@ -20,7 +20,7 @@ describe('trackBy-function', () => {
       assertSuccess('trackBy-function', source);
     });
 
-    it('should have a trackBy function when exported ngFor value is assigned', () => {
+    it('should have a trackBy function with exported index value', () => {
       let source = `
       @Component({
         template: \`

--- a/test/trackByRule.spec.ts
+++ b/test/trackByRule.spec.ts
@@ -20,6 +20,22 @@ describe('trackBy-function', () => {
       assertSuccess('trackBy-function', source);
     });
 
+    it('should have a trackBy function when exported ngFor value is assigned', () => {
+      let source = `
+      @Component({
+        template: \`
+         <ul>
+            <li *ngFor="let person of persons; let i = index; trackBy: trackByFn">
+             {{ person.name }}
+            </li>
+         </ul>
+         \`
+      })
+      class Bar {}
+      `;
+      assertSuccess('trackBy-function', source);
+    });
+
     it('should have a trackBy function', () => {
       let source = `
       @Component({
@@ -35,7 +51,6 @@ describe('trackBy-function', () => {
       `;
       assertSuccess('trackBy-function', source);
     });
-
   });
 
 


### PR DESCRIPTION
- No longer split by "=" as this broke `*ngFor` statements with `let i = index` statements or similar.
- Add test to cover cases like this.
- Fix line length lint error (maybe only on windows).