### PR TITLE
feat: add `no-input-prefix` rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { Rule as NoForwardRefRule } from './noForwardRefRule';
 export { Rule as NoInputRenameRule } from './noInputRenameRule';
 export { Rule as NoOutputNamedAfterStandardEventRule } from './noOutputNamedAfterStandardEventRule';
 export { Rule as NoOutputOnPrefixRule } from './noOutputOnPrefixRule';
+export { Rule as NoInputPrefixRule } from './noInputPrefixRule';
 export { Rule as NoOutputRenameRule } from './noOutputRenameRule';
 export { Rule as NoUnusedCssRule } from './noUnusedCssRule';
 export { Rule as PipeImpureRule } from './pipeImpureRule';

--- a/src/noInputPrefixRule.ts
+++ b/src/noInputPrefixRule.ts
@@ -1,0 +1,55 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import { sprintf } from 'sprintf-js';
+import { NgWalker } from './angular/ngWalker';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'no-input-prefix',
+    type: 'maintainability',
+    description: 'Input names should not be prefixed with the configured disallowed prefixes.',
+    rationale: `HTML attributes are not prefixed. It's considered best not to prefix Inputs.
+    * Example: 'enabled' is prefered over 'isEnabled'.
+    `,
+    options: {
+      'type': 'array',
+      'items': [
+        { 'type': 'string' }
+      ],
+    },
+    optionExamples: [
+      '["is", "can", "should"]'
+    ],
+    optionsDescription: 'Options accept a string array of disallowed input prefixes.',
+    typescriptOnly: true
+  };
+
+  static FAILURE_STRING: string = 'In the class "%s", the input property "%s" should not be prefixed with %s';
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new InputWalker(sourceFile, this.getOptions()));
+  }
+}
+
+class InputWalker extends NgWalker {
+  visitNgInput(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
+    const className = (<any>property).parent.name.text;
+    const memberName = (<any>property.name).text as string;
+    const options = this.getOptions() as string[];
+    let prefixLength: number;
+
+    if (memberName) {
+      const foundInvalid = options.find(x => memberName.startsWith(x));
+      prefixLength = foundInvalid ? foundInvalid.length : 0;
+    }
+
+    if (
+      prefixLength > 0 &&
+      !(memberName.length >= prefixLength + 1 && memberName[prefixLength] !== memberName[prefixLength].toUpperCase())
+    ) {
+      const failureConfig: string[] = [Rule.FAILURE_STRING, className, memberName, options.join(', ')];
+      const errorMessage = sprintf.apply(null, failureConfig);
+      this.addFailure(this.createFailure(property.getStart(), property.getWidth(), errorMessage));
+    }
+  }
+}

--- a/test/noInputPrefixRule.spec.ts
+++ b/test/noInputPrefixRule.spec.ts
@@ -1,0 +1,109 @@
+import { assertSuccess, assertAnnotated } from './testHelper';
+
+describe('no-input-prefix', () => {
+  describe('invalid directive input property', () => {
+    it('should fail, when a component input property is named with is prefix', () => {
+      const source = `
+      @Component()
+      class ButtonComponent {
+        @Input() isDisabled: boolean;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-input-prefix',
+        options: ['is'],
+        message: 'In the class "ButtonComponent", the input property "isDisabled" should not be prefixed with is',
+        source
+      });
+    });
+
+    it('should fail, when a directive input property is named with is prefix', () => {
+      const source = `
+      @Directive()
+      class ButtonDirective {
+        @Input() isDisabled: boolean;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-input-prefix',
+        options: ['is'],
+        message: 'In the class "ButtonDirective", the input property "isDisabled" should not be prefixed with is',
+        source
+      });
+    });
+
+    it('should fail, when a directive input property is named with is prefix', () => {
+      const source = `
+      @Directive()
+      class ButtonDirective {
+        @Input() mustDisable: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-input-prefix',
+        options: ['must'],
+        message: 'In the class "ButtonDirective", the input property "mustDisable" should not be prefixed with must',
+        source
+      });
+    });
+
+    it('should fail, when a directive input property is named with is prefix', () => {
+      const source = `
+      @Directive()
+      class ButtonDirective {
+        @Input() is = true;
+        ~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-input-prefix',
+        options: ['is'],
+        message: 'In the class "ButtonDirective", the input property "is" should not be prefixed with is',
+        source
+      });
+    });
+
+    it('should fail, when a directive input property is named with can prefix', () => {
+      const source = `
+      @Directive()
+      class ButtonDirective {
+        @Input() canEnable = true;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }`;
+      assertAnnotated({
+        ruleName: 'no-input-prefix',
+        options: ['can', 'is'],
+        message: 'In the class "ButtonDirective", the input property "canEnable" should not be prefixed with can, is',
+        source
+      });
+    });
+  });
+
+  describe('valid directive input property', () => {
+    it('should succeed, when a directive input property is properly named', () => {
+      const source = `
+      @Directive()
+      class ButtonComponent {
+         @Input() disabled = true;
+      }`;
+      assertSuccess('no-input-prefix', source);
+    });
+
+    it('should succeed, when a directive input property is properly named', () => {
+      const source = `
+        @Directive()
+        class ButtonComponent {
+           @Input() disabled = "yes";
+        }`;
+      assertSuccess('no-input-prefix', source);
+    });
+
+    it('should succeed, when a component input property is properly named with is', () => {
+      const source = `
+      @Component()
+      class ButtonComponent {
+         @Input() isometric: boolean;
+      }`;
+      assertSuccess('no-input-prefix', source);
+    });
+  });
+});


### PR DESCRIPTION
Not sure, if this might make sense for you guys. But since, I was gonna do it for one of our internal libraries, I though to do it here first. 

Maybe you like it, or maybe not :)

If you'd like it I can also extend it and has it to include other `boolean` prefixes to be excluded from inputs, such as `has`, `should` `can` etc.. And it can be renamed too `no-input-boolean-prefixes`, maybe?

The whole point for the rules is to disable boolean prefixes from input properties. I personally find them a bit dirty, even though they are not listing anyways if one should do them or not in the Angular style guide. But, considering even the native html attributes like `disabled`, `checked` these are never prefixed.

Let me know what are your thoughts anyways :) I'd appreciate any type of feedback Thanks.