### PR TITLE
New rule: disallow full import of RxJS operators

### DIFF
--- a/src/disallowFullImportRxjsOperatorsRule.ts
+++ b/src/disallowFullImportRxjsOperatorsRule.ts
@@ -1,0 +1,75 @@
+import { ImportDeclaration, SourceFile } from 'typescript';
+import { IRuleMetadata, Replacement, RuleFailure, Rules, RuleWalker } from 'tslint';
+
+const disallowedImports: string[] = [
+  // lettable import
+  '\'rxjs/operators\'',
+  '"rxjs/operators"',
+  // not-lettable import
+  'rxjs/add/operator',
+];
+
+export class Rule extends Rules.AbstractRule {
+  public static metadata: IRuleMetadata = {
+    ruleName: 'disallow-full-import-rxjs-operators',
+    type: 'maintainability',
+    description: 'RxJS operators should be imported from it\'s own scope.',
+    rationale: 'Helps to improve an angular bundle size. Angular has a dependency' +
+    ' on RxJS and it helps to not increase a final bundle size.',
+    options: null,
+    optionsDescription: 'Not configurable.',
+    typescriptOnly: true,
+  };
+
+  public static FAILURE_STRING = 'RxJS operators should be imported from their own scope.';
+
+  public apply(sourceFile: SourceFile): RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends RuleWalker {
+  public visitImportDeclaration(importDeclaration: ImportDeclaration): void {
+    const importDeclarationText: string = importDeclaration.getText();
+
+    if (this.hasDisallowedImport(importDeclarationText)) {
+      this.addFailureAt(
+        importDeclaration.getStart(),
+        importDeclaration.getWidth(),
+        Rule.FAILURE_STRING,
+        this.getFix(importDeclaration),
+      );
+    }
+  }
+
+  private hasDisallowedImport(importDeclarationText: string): boolean {
+    return disallowedImports.some((i: string): boolean => importDeclarationText.indexOf(i) !== -1);
+  }
+
+  private getFix(importDeclaration: ImportDeclaration): Replacement {
+    const fix: string = this.getRxJsOperators(importDeclaration)
+      .reduce((prev: string[], curr: string): string[] => prev.concat([this.getRxJsOperatorImport(curr)]), [])
+      .join('\n');
+
+    return new Replacement(importDeclaration.getStart(), importDeclaration.getWidth(), fix);
+  }
+
+  private getRxJsOperators(importDeclaration: ImportDeclaration): string[] {
+    if (!importDeclaration.importClause) {
+      const operator: RegExpExecArray | null = /rxjs\/add\/operator\/(.*)['|"]+/.exec(importDeclaration.getText());
+      return operator && operator[1] ? [operator[1]] : [];
+    }
+
+    return importDeclaration
+      .importClause
+      .getText()
+      .replace(/[\s{}]*/g, '')
+      .split(',')
+      .filter((operator: string): boolean => operator.length > 0)
+      .sort();
+  }
+
+  private getRxJsOperatorImport(operator: string): string {
+    return `import {${operator}} from 'rxjs/operators/${operator}';`;
+  }
+}

--- a/test/disallowFullImportRxjsOperatorsRule.spec.ts
+++ b/test/disallowFullImportRxjsOperatorsRule.spec.ts
@@ -1,0 +1,59 @@
+import { assertAnnotated, assertSuccess } from './testHelper';
+
+describe('disallow-full-import-rxjs-operators', () => {
+  describe('invalid RxJS import', () => {
+    it('should fail when the import is \'rxjs/add/operator/*\'', () => {
+      let source = `
+          import 'rxjs/add/operator/tap'
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `;
+      assertAnnotated({
+        ruleName: 'disallow-full-import-rxjs-operators',
+        message: 'RxJS operators should be imported from their own scope.',
+        source
+      });
+    });
+
+    it('should fail when the import is from \'rxjs/operators\'', () => {
+      let source = `
+          import {tap} from 'rxjs/operators'
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `;
+      assertAnnotated({
+        ruleName: 'disallow-full-import-rxjs-operators',
+        message: 'RxJS operators should be imported from their own scope.',
+        source
+      });
+    });
+
+    it('should fail when multiple imports are from \'rxjs/operators\'', () => {
+      let source = `
+          import {delay, tap} from 'rxjs/operators'
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `;
+      assertAnnotated({
+        ruleName: 'disallow-full-import-rxjs-operators',
+        message: 'RxJS operators should be imported from their own scope.',
+        source
+      });
+    });
+  });
+
+  describe('valid import spacing', () => {
+    it('should succeed with valid spacing', () => {
+      let source = `
+        import {
+          tap
+        } from 'rxjs/operators/tap';
+      `;
+      assertSuccess('disallow-full-import-rxjs-operators', source);
+    });
+
+    it('should work with alias imports', () => {
+      let source = `
+        import {tap} from 'rxjs/operators/tap';
+      `;
+      assertSuccess('disallow-full-import-rxjs-operators', source);
+    });
+  });
+});


### PR DESCRIPTION
The reason behind this PR is better described in my article:
https://medium.com/p/prevent-coding-mistakes-write-a-tslint-rule-specific-for-your-own-project-987d26f91647

Shortly: it can decrease a size of a bundle when RxJS operators are imported in a wrong way

_I know it is not exactly Angular related, but Angular requires RxJS as a dependency. Therefore I think it could be part of the Styleguide._