### PR TITLE
fix: cannot find rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,6 @@ export { Rule as UseViewEncapsulationRule } from './useViewEncapsulationRule';
 export { Rule as TemplatesNoNegatedAsync } from './templatesNoNegatedAsyncRule';
 export { Rule as TrackByFunctionRule } from './trackByFunctionRule';
 export * from './angular/config';
+
+// this file exists for tslint to resolve the rules directory
+export const rulesDirectory = '.';


### PR DESCRIPTION
At the moment doing something like
```json
{
  "extends": ["codelyzer"],
  "rules": {
    "angular-whitespace": [true, "check-interpolation", "check-semicolon"],
    "banana-in-box": true,
    "templates-no-negated-async": true,
    "directive-selector": [true, "attribute", "sg", "camelCase"],
  }
}
```

Will not work and you'll end up with loads of errors example
```bash
Could not find implementations for the following rules specified in the configuration:
    angular-whitespace
    banana-in-box
    contextual-life-cycle
```

This is because tslint requires a `rulesDirectory` to resolve the rules.

