### PR TITLE
fix wrong usages of 'trackBy' micro-syntax in testing cases

### DIFF
--- a/test/angularWhitespaceRule.spec.ts
+++ b/test/angularWhitespaceRule.spec.ts
@@ -633,7 +633,7 @@ describe('failure', () => {
       it('should fail and apply proper replacement when equality sign exists within the directive expression', () => {
         let source = `
           @Component({
-            template: \` <div *ngFor="let item of list;trackBy item?.id; let $index=index">{{ item.title }}</div>
+            template: \` <div *ngFor="let item of list;trackBy trackById; let $index=index">{{ item.title }}</div>
                                                       ~~
             \`
           })
@@ -648,7 +648,7 @@ describe('failure', () => {
         const res = Replacement.applyAll(source, failures[0].getFix());
         expect(res).to.eq(`
           @Component({
-            template: \` <div *ngFor="let item of list; trackBy item?.id; let $index=index">{{ item.title }}</div>
+            template: \` <div *ngFor="let item of list; trackBy trackById; let $index=index">{{ item.title }}</div>
                                                       ~~
             \`
           })


### PR DESCRIPTION
The 'trackBy' micro-syntax must use a function to check references, instead of references to object properties directly.
The old testing cases I written were wrong usages/examples, that should be fixed.