### PR TITLE
fix(537): no-output-named-after-standard-event checks output rename

### DIFF
--- a/src/noOutputNamedAfterStandardEventRule.ts
+++ b/src/noOutputNamedAfterStandardEventRule.ts
@@ -15,7 +15,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   static FAILURE_STRING: string = 'In the class "%s", the output ' +
-    'property "%s" should not be named after a standard event.';
+    'property "%s" should not be named or renamed after a standard event.';
 
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(
@@ -204,8 +204,9 @@ export class OutputMetadataWalker extends NgWalker {
   visitNgOutput(property: ts.PropertyDeclaration, output: ts.Decorator, args: string[]) {
     let className = (<any>property).parent.name.text;
     let memberName = (<any>property.name).text;
+    let outputName = args.length === 0 ? memberName : args[0];
 
-    if (memberName && this.standardEventNames.get(memberName)) {
+    if (outputName && this.standardEventNames.get(outputName)) {
       const failureConfig: string[] = [Rule.FAILURE_STRING, className, memberName];
       const errorMessage = sprintf.apply(null, failureConfig);
       this.addFailure(

--- a/test/noOutputNamedAfterStandardEventRule.spec.ts
+++ b/test/noOutputNamedAfterStandardEventRule.spec.ts
@@ -2,7 +2,7 @@ import { assertSuccess, assertAnnotated } from './testHelper';
 
 describe('no-output-named-after-standard-event', () => {
   describe('invalid directive output property', () => {
-    it('should fail, when component output property is named with change prefix', () => {
+    it('should fail, when component output property is named "change"', () => {
       const source = `
         @Component()
         class ButtonComponent {
@@ -13,12 +13,12 @@ describe('no-output-named-after-standard-event', () => {
 
       assertAnnotated({
         ruleName: 'no-output-named-after-standard-event',
-        message: 'In the class "ButtonComponent", the output property "change" should not be named after a standard event.',
+        message: 'In the class "ButtonComponent", the output property "change" should not be named or renamed after a standard event.',
         source
       });
     });
 
-    it('should fail, when directive output property is named with change prefix', () => {
+    it('should fail, when directive output property is named "change"', () => {
       const source = `
         @Directive()
         class ButtonDirective {
@@ -29,7 +29,39 @@ describe('no-output-named-after-standard-event', () => {
 
       assertAnnotated({
         ruleName: 'no-output-named-after-standard-event',
-        message: 'In the class "ButtonDirective", the output property "change" should not be named after a standard event.',
+        message: 'In the class "ButtonDirective", the output property "change" should not be named or renamed after a standard event.',
+        source
+      });
+    });
+
+    it('should fail, when component output property is renamed to "change"', () => {
+      const source = `
+        @Component()
+        class ButtonComponent {
+          @Output("change") _change = new EventEmitter<any>();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `;
+
+      assertAnnotated({
+        ruleName: 'no-output-named-after-standard-event',
+        message: 'In the class "ButtonComponent", the output property "_change" should not be named or renamed after a standard event.',
+        source
+      });
+    });
+
+    it('should fail, when directive output property is renamed to "change"', () => {
+      const source = `
+        @Directive()
+        class ButtonDirective {
+          @Output("change") _change = new EventEmitter<any>();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `;
+
+      assertAnnotated({
+        ruleName: 'no-output-named-after-standard-event',
+        message: 'In the class "ButtonDirective", the output property "_change" should not be named or renamed after a standard event.',
         source
       });
     });
@@ -51,6 +83,26 @@ describe('no-output-named-after-standard-event', () => {
         @Directive()
         class ButtonDirective {
           @Output() buttonChange = new EventEmitter<any>();
+        }
+      `;
+      assertSuccess('no-output-named-after-standard-event', source);
+    });
+
+    it('should succeed, when a component output property is properly renamed', () => {
+      const source = `
+        @Component()
+        class ButtonComponent {
+          @Output("buttonChange") _buttonChange = new EventEmitter<any>();
+        }
+      `;
+      assertSuccess('no-output-named-after-standard-event', source);
+    });
+
+    it('should succeed, when a directive output property is properly renamed', () => {
+      const source = `
+        @Directive()
+        class ButtonDirective {
+          @Output("buttonChange") _buttonChange = new EventEmitter<any>();
         }
       `;
       assertSuccess('no-output-named-after-standard-event', source);


### PR DESCRIPTION
Fixes #537 