### PR TITLE
Add support for nested i18n items and removed ng-container restriction

### DIFF
--- a/src/i18nRule.ts
+++ b/src/i18nRule.ts
@@ -73,13 +73,12 @@ class I18NTextVisitor extends BasicTemplateAstVisitor implements ConfigurableVis
   }
 
   visitElement(element: ast.ElementAst, context: BasicTemplateAstVisitor) {
-    if (element.name !== 'ng-container') {
-      this.hasI18n = element.attrs.some(e => e.name === 'i18n');
-    }
+    const originalI18n = this.hasI18n;
+    this.hasI18n = originalI18n || element.attrs.some(e => e.name === 'i18n');
     this.nestedElements.push(element.name);
     super.visitElement(element, context);
     this.nestedElements.pop();
-    this.hasI18n = false;
+    this.hasI18n = originalI18n;
   }
 
   getOption(): Option {

--- a/test/i18nRule.spec.ts
+++ b/test/i18nRule.spec.ts
@@ -24,6 +24,18 @@ describe('i18n', () => {
       `;
       assertSuccess('i18n', source, ['check-id']);
     });
+    
+    it('should work with proper id on ng-container', () => {
+      const source = `
+      @Component({
+        template: \`
+          <ng-container i18n="test@@foo">Text</ng-container>
+        \`
+      })
+      class Bar {}
+      `;
+      assertSuccess('i18n', source, ['check-id']);
+    });
 
     it('should work with proper i18n attribute', () => {
       const source = `
@@ -130,6 +142,18 @@ describe('i18n', () => {
       `;
       assertSuccess('i18n', source, ['check-text']);
     });
+    
+    it('should work with i18n attribute on ng-container', () => {
+      const source = `
+      @Component({
+        template: \`
+          <ng-container i18n>Text</ng-container>
+        \`
+      })
+      class Bar {}
+      `;
+      assertSuccess('i18n', source, ['check-text']);
+    });
 
     it('should work with plural', () => {
       const source = `
@@ -171,6 +195,22 @@ describe('i18n', () => {
       assertSuccess('i18n', source, ['check-text']);
     });
 
+    it('should work with multiple nested elements', () => {
+      const source = `
+      @Component({
+        template: \`
+          <ul i18n>
+            <li>ItemA</li>
+            <li>ItemB</li>
+            <li>ItemC</li>
+          </ul>
+        \`
+      })
+      class Bar {}
+      `;
+      assertSuccess('i18n', source, ['check-text']);
+    });
+
     it('should fail with missing id string', () => {
       const source = `
       @Component({
@@ -194,7 +234,7 @@ describe('i18n', () => {
       @Component({
         template: \`
           <div>
-            <span i18n>foo</div>
+            <span i18n>foo</span>
             <div>Text</div>
                  ~~~~
           </div>
@@ -295,6 +335,38 @@ describe('i18n', () => {
           },
           endPosition: {
             line: 5,
+            character: 8
+          }
+        },
+        ['check-text']
+      );
+    });
+
+    it('should fail with text outside multiple nested elements', () => {
+      const source = `
+      @Component({
+        template: \`
+          <ul i18n>
+            <li>ItemA</li>
+            <li>ItemB</li>
+            <li>ItemC</li>
+          </ul>
+          Text
+        \`
+      })
+      class Bar {}
+      `;
+      assertFailure(
+        'i18n',
+        source,
+        {
+          message: 'Each element containing text node should have an i18n attribute',
+          startPosition: {
+            line: 7,
+            character: 15
+          },
+          endPosition: {
+            line: 9,
             character: 8
           }
         },

--- a/test/i18nRule.spec.ts
+++ b/test/i18nRule.spec.ts
@@ -24,7 +24,7 @@ describe('i18n', () => {
       `;
       assertSuccess('i18n', source, ['check-id']);
     });
-    
+
     it('should work with proper id on ng-container', () => {
       const source = `
       @Component({
@@ -142,7 +142,7 @@ describe('i18n', () => {
       `;
       assertSuccess('i18n', source, ['check-text']);
     });
-    
+
     it('should work with i18n attribute on ng-container', () => {
       const source = `
       @Component({


### PR DESCRIPTION
This fix will address #530 regarding `ng-container` checking.  I verified that the unit test added for #506 still passes.

It will also address another problem that my team was having which was causing the `check-text` to report failure for nested items like this:

```
<ul i18n="@@myList">
    <li>List Item 1</li>
    <li>List Item 2</li>
    <li>List Item 3</li>
</ul>
```
This is valid syntax resulting in the following xlf output:

```
<trans-unit id="myList" datatype="html">
    <source>
        <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li&gt;"/>List Item 1<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li&gt;"/>
        <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li&gt;"/>List Item 2<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li&gt;"/>
        <x id="START_LIST_ITEM" ctype="x-li" equiv-text="&lt;li&gt;"/>List Item 3<x id="CLOSE_LIST_ITEM" ctype="x-li" equiv-text="&lt;/li&gt;"/>
    </source>
</trans-unit>
```
Since they were touching the same area of the code I just put the changes together, but if necessary I can submit as multiple requests.