### PR TITLE
refactor: replace/remove deprecated method calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format:base": "prettier --config ./.prettierrc \"*.{json,md}\" \"src/**/*.{css,scss,ts}\" \"test/**/*.{css,scss,ts}\"",
     "format:check": "npm run format:base -- --list-different",
     "format:fix": "npm run format:base -- --write",
-    "lint": "tslint -c tslint.json \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "tslint -p . -c tslint.json \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
     "release": "npm run build && rimraf dist && tsc -p tsconfig-release.json && npm run copy:common && npm run prepare:package && cross-env BUILD_TYPE=prod npm run set:vars",
     "build": "rimraf dist && tsc && npm run format:check && npm run lint && npm t",

--- a/src/angular/ngWalker.ts
+++ b/src/angular/ngWalker.ts
@@ -205,7 +205,11 @@ export class NgWalker extends Lint.RuleWalker {
       compiler.templateVisitAll(referenceVisitor, roots, null);
       visitor._variables = referenceVisitor.variables;
       roots.forEach(r => visitor.visit(r, context.controller));
-      visitor.getFailures().forEach(f => this.addFailure(f));
+      visitor
+        .getFailures()
+        .forEach(f =>
+          this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
+        );
     }
   }
 
@@ -216,7 +220,11 @@ export class NgWalker extends Lint.RuleWalker {
       const sourceFile = this.getContextSourceFile(styleMetadata.url, styleMetadata.style.source);
       const visitor = new this._config.cssVisitorCtrl(sourceFile, this._originalOptions, context, styleMetadata, baseStart);
       style.visit(visitor);
-      visitor.getFailures().forEach(f => this.addFailure(f));
+      visitor
+        .getFailures()
+        .forEach(f =>
+          this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
+        );
     }
   }
 

--- a/src/angular/sourceMappingVisitor.ts
+++ b/src/angular/sourceMappingVisitor.ts
@@ -104,6 +104,7 @@ export class SourceMappingVisitor extends RuleWalker {
 
   createFailure(s: number, l: number, message: string, fix?: Fix): RuleFailure {
     const { start, length } = this.getMappedInterval(s, l);
+    // tslint:disable-next-line:deprecation
     return super.createFailure(start, length, message, fix);
   }
 

--- a/src/angular/styles/cssLexer.ts
+++ b/src/angular/styles/cssLexer.ts
@@ -88,8 +88,8 @@ export class CssLexer {
 
 export function cssScannerError(token: CssToken, message: string): Error {
   const error = Error('CssParseError: ' + message);
-  (error as any)[ERROR_RAW_MESSAGE] = message;
-  (error as any)[ERROR_TOKEN] = token;
+  error[ERROR_RAW_MESSAGE] = message;
+  error[ERROR_TOKEN] = token;
   return error;
 }
 
@@ -97,11 +97,11 @@ const ERROR_TOKEN = 'ngToken';
 const ERROR_RAW_MESSAGE = 'ngRawMessage';
 
 export function getRawMessage(error: Error): string {
-  return (error as any)[ERROR_RAW_MESSAGE];
+  return error[ERROR_RAW_MESSAGE];
 }
 
 export function getToken(error: Error): CssToken {
-  return (error as any)[ERROR_TOKEN];
+  return error[ERROR_TOKEN];
 }
 
 function _trackWhitespace(mode: CssLexerMode) {

--- a/src/angular/styles/cssParser.ts
+++ b/src/angular/styles/cssParser.ts
@@ -125,8 +125,8 @@ export class CssParser {
     this._errors = [];
 
     const result = new ParsedCssResult(errors, ast);
-    this._file = null as any;
-    this._scanner = null as any;
+    this._file = null;
+    this._scanner = null;
     return result;
   }
 

--- a/src/angular/templates/basicTemplateAstVisitor.ts
+++ b/src/angular/templates/basicTemplateAstVisitor.ts
@@ -7,7 +7,6 @@ import { ExpTypes } from '../expressionTypes';
 import { ComponentMetadata } from '../metadata';
 import { RecursiveAngularExpressionVisitor } from './recursiveAngularExpressionVisitor';
 import { SourceMappingVisitor } from '../sourceMappingVisitor';
-import { NgWalker } from '../ngWalker';
 
 const getExpressionDisplacement = (binding: any) => {
   let attrLen = 0;
@@ -184,6 +183,7 @@ export class BasicTemplateAstVisitor extends SourceMappingVisitor implements ast
     templateVisitor.preDefinedVariables = this._variables;
     templateVisitor.parentAST = prop;
     templateVisitor.visit(ast);
+    // tslint:disable-next-line:deprecation
     templateVisitor.getFailures().forEach(f => this.addFailure(f));
   }
 }

--- a/src/angular/templates/jitReflector.ts
+++ b/src/angular/templates/jitReflector.ts
@@ -13,7 +13,6 @@ import {
   NgModuleFactory,
   NgModuleRef,
   QueryList,
-  Renderer,
   SecurityContext,
   TRANSLATIONS_FORMAT,
   TemplateRef,
@@ -54,7 +53,6 @@ const builtinExternalReferences = createBuiltinExternalReferencesMap();
 export class JitReflector implements CompileReflector {
   tryAnnotations: any;
   private reflectionCapabilities: ReflectionCapabilities;
-  private builtinExternalReferences = new Map<ExternalReference, any>();
 
   constructor() {
     this.reflectionCapabilities = new ReflectionCapabilities();
@@ -133,7 +131,6 @@ function createBuiltinExternalReferencesMap() {
   map.set(Identifiers.interpolate, ɵinterpolate);
   map.set(Identifiers.EMPTY_ARRAY, ɵEMPTY_ARRAY);
   map.set(Identifiers.EMPTY_MAP, ɵEMPTY_MAP);
-  map.set(Identifiers.Renderer, Renderer);
   map.set(Identifiers.viewDef, ɵvid);
   map.set(Identifiers.elementDef, ɵeld);
   map.set(Identifiers.anchorDef, ɵand);

--- a/src/angular/templates/templateParser.ts
+++ b/src/angular/templates/templateParser.ts
@@ -113,7 +113,7 @@ export const parseTemplate = (template: string, directives: DirectiveDeclaration
         ngContentSelectors: this.ngContentSelectors,
         encapsulation: this.encapsulation,
         summaryKind: summaryKind
-      } as any;
+      };
     }
   };
 
@@ -164,10 +164,11 @@ export const parseTemplate = (template: string, directives: DirectiveDeclaration
             queries: [],
             viewQueries: [],
             entryComponents: [],
+            guards: [],
             componentViewType: null,
             rendererType: null,
             componentFactory: null
-          } as any),
+          }),
           template,
           defaultDirectives,
           [],
@@ -193,10 +194,11 @@ export const parseTemplate = (template: string, directives: DirectiveDeclaration
             queries: [],
             viewQueries: [],
             entryComponents: [],
+            guards: [],
             componentViewType: null,
             rendererType: null,
             componentFactory: null
-          } as any),
+          }),
           template,
           defaultDirectives,
           [],
@@ -222,10 +224,11 @@ export const parseTemplate = (template: string, directives: DirectiveDeclaration
             queries: [],
             viewQueries: [],
             entryComponents: [],
+            guards: [],
             componentViewType: null,
             rendererType: null,
             componentFactory: null
-          } as any),
+          }),
           template,
           defaultDirectives,
           [],

--- a/src/bananaInBoxRule.ts
+++ b/src/bananaInBoxRule.ts
@@ -8,10 +8,10 @@ const InvalidSyntaxBoxOpen = '([';
 const InvalidSyntaxBoxClose = '])';
 const ValidSyntaxOpen = '[(';
 const ValidSyntaxClose = ')]';
-const InvalidSyntaxBoxRe = new RegExp('\\[(.*?)\\]');
+const InvalidSyntaxBoxRe = /\[(.*?)\]/;
 
 const getReplacements = (text: ast.BoundEventAst, absolutePosition: number) => {
-  const expr: string = (text.sourceSpan as any).toString();
+  const expr = text.sourceSpan.toString();
   const internalStart = expr.indexOf(InvalidSyntaxBoxOpen);
   const internalEnd = expr.lastIndexOf(InvalidSyntaxBoxClose);
   const len = internalEnd - internalStart - InvalidSyntaxBoxClose.length;
@@ -35,12 +35,12 @@ class BananaInBoxTemplateVisitor extends BasicTemplateAstVisitor {
       }
 
       if (error) {
-        const expr: any = (<any>prop.sourceSpan).toString();
+        const expr = prop.sourceSpan.toString();
         const internalStart = expr.indexOf(InvalidSyntaxBoxOpen) + 1;
         const start = prop.sourceSpan.start.offset + internalStart;
         const absolutePosition = this.getSourcePosition(start - 1);
 
-        this.addFailure(this.createFailure(start, expr.trim().length, error, getReplacements(prop, absolutePosition)));
+        this.addFailureAt(start, expr.trim().length, error, getReplacements(prop, absolutePosition));
       }
     }
     super.visitEvent(prop, context);

--- a/src/contextualLifeCycleRule.ts
+++ b/src/contextualLifeCycleRule.ts
@@ -33,75 +33,61 @@ export class ClassMetadataWalker extends NgWalker {
   isPipe = false;
 
   visitMethodDeclaration(method: ts.MethodDeclaration) {
-    const methodName = (method.name as ts.StringLiteral).text;
+    const methodName = method.name.getText();
 
     if (methodName === 'ngOnInit') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngOnInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngOnInit()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngOnInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngOnInit()');
       }
     }
 
     if (methodName === 'ngOnChanges') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngOnChanges()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngOnChanges()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngOnChanges()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngOnChanges()');
       }
     }
 
     if (methodName === 'ngDoCheck') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngDoCheck()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngDoCheck()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngDoCheck()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngDoCheck()');
       }
     }
 
     if (methodName === 'ngAfterContentInit') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngAfterContentInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngAfterContentInit()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngAfterContentInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngAfterContentInit()');
       }
     }
 
     if (methodName === 'ngAfterContentChecked') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngAfterContentChecked()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngAfterContentChecked()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngAfterContentChecked()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngAfterContentChecked()');
       }
     }
 
     if (methodName === 'ngAfterViewInit') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngAfterViewInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngAfterViewInit()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngAfterViewInit()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngAfterViewInit()');
       }
     }
 
     if (methodName === 'ngAfterViewChecked') {
       if (this.isInjectable) {
-        let failureConfig: string[] = [this.className, '@Injectable', 'ngAfterViewChecked()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Injectable', 'ngAfterViewChecked()');
       } else if (this.isPipe) {
-        let failureConfig: string[] = [this.className, '@Pipe', 'ngAfterViewChecked()'];
-        this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+        this.generateFailure(method, this.className, '@Pipe', 'ngAfterViewChecked()');
       }
     }
 
@@ -144,7 +130,7 @@ export class ClassMetadataWalker extends NgWalker {
     super.visitNgPipe(controller, decorator);
   }
 
-  private generateFailure(start: number, width: number, failureConfig: string[]) {
-    this.addFailure(this.createFailure(start, width, vsprintf(Rule.FAILURE_STRING, failureConfig)));
+  private generateFailure(method: ts.MethodDeclaration, ...failureConfig: string[]) {
+    this.addFailureAtNode(method, vsprintf(Rule.FAILURE_STRING, failureConfig));
   }
 }

--- a/src/decoratorNotAllowedRule.ts
+++ b/src/decoratorNotAllowedRule.ts
@@ -1,6 +1,6 @@
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
+import { vsprintf } from 'sprintf-js';
 import { NgWalker } from './angular/ngWalker';
 import { ComponentMetadata, DirectiveMetadata } from './angular/metadata';
 
@@ -52,77 +52,61 @@ export class ClassMetadataWalker extends NgWalker {
 
   protected visitNgInput(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@Input'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@Input');
     }
     super.visitNgInput(property, input, args);
   }
 
   protected visitNgOutput(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@Output'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@Output');
     }
     super.visitNgInput(property, input, args);
   }
 
   protected visitNgHostBinding(property: ts.PropertyDeclaration, decorator: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@HostBinding'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@HostBinding');
     }
     super.visitNgHostBinding(property, decorator, args);
   }
 
   protected visitNgHostListener(method: ts.MethodDeclaration, decorator: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@HostListener'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(method.getStart(), method.getWidth(), failureConfig);
+      this.generateFailure(method, this.className, '@Injectable', '@HostListener');
     }
     super.visitNgHostListener(method, decorator, args);
   }
 
   protected visitNgContentChild(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@ContentChild'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@ContentChild');
     }
     super.visitNgContentChild(property, input, args);
   }
 
   protected visitNgContentChildren(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@ContentChildren'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@ContentChildren');
     }
     super.visitNgContentChildren(property, input, args);
   }
 
   protected visitNgViewChild(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@ViewChild'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@ViewChild');
     }
     super.visitNgViewChild(property, input, args);
   }
 
   protected visitNgViewChildren(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
     if (this.isInjectable) {
-      let failureConfig: string[] = [this.className, '@Injectable', '@ViewChildren'];
-      failureConfig.unshift(Rule.INJECTABLE_FAILURE_STRING);
-      this.generateFailure(property.getStart(), property.getWidth(), failureConfig);
+      this.generateFailure(property, this.className, '@Injectable', '@ViewChildren');
     }
     super.visitNgViewChildren(property, input, args);
   }
 
-  private generateFailure(start: number, width: number, failureConfig: string[]) {
-    this.addFailure(this.createFailure(start, width, sprintf.apply(this, failureConfig)));
+  private generateFailure(property: ts.Node, ...failureConfig: string[]) {
+    this.addFailureAtNode(property, vsprintf(Rule.INJECTABLE_FAILURE_STRING, failureConfig));
   }
 }

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -66,9 +66,7 @@ export class ClassMetadataWalker extends NgWalker {
       }
     }
     if (!Rule.validate(className, suffixes)) {
-      this.addFailure(
-        this.createFailure(name.getStart(), name.getWidth(), sprintf.apply(this, [Rule.FAILURE, className, suffixes.join(', ')]))
-      );
+      this.addFailureAtNode(name, sprintf(Rule.FAILURE, className, suffixes.join(', ')));
     }
     super.visitNgDirective(metadata);
   }

--- a/src/enforceComponentSelectorRule.ts
+++ b/src/enforceComponentSelectorRule.ts
@@ -25,14 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 export class EnforceComponentSelectorValidatorWalker extends NgWalker {
   protected visitNgComponent(metadata: ComponentMetadata) {
     if (!metadata.selector) {
-      const failureConfig: string[] = [metadata.controller.name.text];
-      failureConfig.unshift(Rule.SELECTOR_FAILURE);
-      this.generateFailure(metadata.decorator.getStart(), metadata.decorator.getWidth(), failureConfig);
+      this.addFailureAtNode(metadata.decorator, sprintf(Rule.SELECTOR_FAILURE, metadata.controller.name.text));
     }
     super.visitNgComponent(metadata);
-  }
-
-  private generateFailure(start: number, width: number, failureConfig: string[]) {
-    this.addFailure(this.createFailure(start, width, sprintf.apply(this, failureConfig)));
   }
 }

--- a/src/importDestructuringSpacingRule.ts
+++ b/src/importDestructuringSpacingRule.ts
@@ -38,20 +38,7 @@ class ImportDestructuringSpacingWalker extends RuleWalker {
     super.visitNamedImports(node);
   }
 
-  private validateNamedImports(node: NamedImports): void {
-    const nodeText = node.getText();
-
-    if (isBlankOrMultilineImport(nodeText)) {
-      return;
-    }
-
-    const totalLeadingSpaces = nodeText.match(/^\{(\s*)/)[1].length;
-    const totalTrailingSpaces = nodeText.match(/(\s*)}$/)[1].length;
-
-    if (totalLeadingSpaces === 1 && totalTrailingSpaces === 1) {
-      return;
-    }
-
+  private getFix(node: NamedImports, totalLeadingSpaces: number, totalTrailingSpaces: number): Fix {
     const nodeStartPos = node.getStart();
     const nodeEndPos = node.getEnd();
     let fix: Fix = [];
@@ -67,6 +54,25 @@ class ImportDestructuringSpacingWalker extends RuleWalker {
     } else if (totalTrailingSpaces > 1) {
       fix.push(Replacement.deleteText(nodeEndPos - totalTrailingSpaces, totalTrailingSpaces - 1));
     }
+
+    return fix;
+  }
+
+  private validateNamedImports(node: NamedImports): void {
+    const nodeText = node.getText();
+
+    if (isBlankOrMultilineImport(nodeText)) {
+      return;
+    }
+
+    const totalLeadingSpaces = nodeText.match(/^\{(\s*)/)[1].length;
+    const totalTrailingSpaces = nodeText.match(/(\s*)}$/)[1].length;
+
+    if (totalLeadingSpaces === 1 && totalTrailingSpaces === 1) {
+      return;
+    }
+
+    const fix = this.getFix(node, totalLeadingSpaces, totalTrailingSpaces);
 
     this.addFailureAtNode(node, getFailureMessage(), fix);
   }

--- a/src/noConflictingLifeCycleHooksRule.ts
+++ b/src/noConflictingLifeCycleHooksRule.ts
@@ -51,12 +51,12 @@ export class ClassMetadataWalker extends Lint.RuleWalker {
     const matchesAllHooks = lifecycleHooksMethods.every(l => interfaces.indexOf(l) !== -1);
 
     if (matchesAllHooks) {
-      this.addFailureAtNode(node, sprintf.apply(this, [Rule.FAILURE_STRING, node.name.text]));
+      this.addFailureAtNode(node, sprintf(Rule.FAILURE_STRING, node.name.text));
     }
   }
 
   private validateMethods(node: ts.ClassDeclaration): void {
-    const methodNames = node.members.filter(m => m.kind === ts.SyntaxKind.MethodDeclaration).map<string>(m => (m.name as any).text);
+    const methodNames = node.members.filter(m => m.kind === ts.SyntaxKind.MethodDeclaration).map(m => m.name.getText());
     const matchesAllHooks = lifecycleHooksMethods.every(l => {
       return methodNames.indexOf(`${hooksPrefix}${l}`) !== -1;
     });

--- a/src/noForwardRefRule.ts
+++ b/src/noForwardRefRule.ts
@@ -31,17 +31,18 @@ export class ExpressionCallMetadataWalker extends Lint.RuleWalker {
 
   private validateCallExpression(callExpression) {
     if (callExpression.expression.text === 'forwardRef') {
-      let currentNode: any = callExpression;
+      let currentNode = callExpression;
       while (currentNode.parent.parent) {
         currentNode = currentNode.parent;
       }
-      let failureConfig: string[] = [];
+
+      let failure: string;
       if (currentNode.kind === SyntaxKind.current().VariableStatement) {
-        failureConfig = [Rule.FAILURE_IN_VARIABLE, currentNode.declarationList.declarations[0].name.text];
+        failure = sprintf(Rule.FAILURE_IN_VARIABLE, currentNode.declarationList.declarations[0].name.text);
       } else {
-        failureConfig = [Rule.FAILURE_IN_CLASS, currentNode.name.text];
+        failure = sprintf(Rule.FAILURE_IN_CLASS, currentNode.name.text);
       }
-      this.addFailure(this.createFailure(callExpression.getStart(), callExpression.getWidth(), sprintf.apply(this, failureConfig)));
+      this.addFailureAtNode(callExpression, failure);
     }
   }
 }

--- a/src/noLifeCycleCallRule.ts
+++ b/src/noLifeCycleCallRule.ts
@@ -1,4 +1,3 @@
-import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { NgWalker } from './angular/ngWalker';
@@ -53,7 +52,7 @@ export class ExpressionCallMetadataWalker extends NgWalker {
     const expression = ts.isPropertyAccessExpression(node.expression) ? node.expression.expression : undefined;
 
     const isSuperCall = expression && expression.kind === ts.SyntaxKind.SuperKeyword;
-    const isLifecycleCall = name && ts.isIdentifier(name) && lifecycleHooksMethods.has(name.text as any);
+    const isLifecycleCall = name && ts.isIdentifier(name) && lifecycleHooksMethods.has(name.text as LifecycleHooksMethods);
 
     if (isLifecycleCall && !isSuperCall) {
       this.addFailureAtNode(node, Rule.FAILURE_STRING);

--- a/src/noOutputNamedAfterStandardEventRule.ts
+++ b/src/noOutputNamedAfterStandardEventRule.ts
@@ -203,9 +203,8 @@ export class OutputMetadataWalker extends NgWalker {
     let outputName = args.length === 0 ? memberName : args[0];
 
     if (outputName && this.standardEventNames.get(outputName)) {
-      const failureConfig: string[] = [Rule.FAILURE_STRING, className, memberName];
-      const errorMessage = sprintf.apply(null, failureConfig);
-      this.addFailure(this.createFailure(property.getStart(), property.getWidth(), errorMessage));
+      const errorMessage = sprintf(Rule.FAILURE_STRING, className, memberName);
+      this.addFailureAtNode(property, errorMessage);
     }
     super.visitNgOutput(property, output, args);
   }

--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -29,9 +29,7 @@ class OutputWalker extends NgWalker {
     const memberName = (<any>property.name).text as string;
 
     if (memberName && memberName.startsWith('on') && !(memberName.length >= 3 && memberName[2] !== memberName[2].toUpperCase())) {
-      const failureConfig: string[] = [Rule.FAILURE_STRING, className, memberName];
-      const errorMessage = sprintf.apply(null, failureConfig);
-      this.addFailure(this.createFailure(property.getStart(), property.getWidth(), errorMessage));
+      this.addFailureAtNode(property, sprintf(Rule.FAILURE_STRING, className, memberName));
     }
     super.visitNgOutput(property, output, args);
   }

--- a/src/noTemplateCallExpressionRule.ts
+++ b/src/noTemplateCallExpressionRule.ts
@@ -34,13 +34,13 @@ class TemplateVisitor extends BasicTemplateAstVisitor {
 
 class ExpressionVisitor extends RecursiveAngularExpressionVisitor {
   visitFunctionCall(node: e.FunctionCall, context: any) {
-    this.addFailureAt(node.span.start, node.span.end - node.span.start, Rule.FAILURE_STRING);
+    this.addFailureFromStartToEnd(node.span.start, node.span.end, Rule.FAILURE_STRING);
 
     super.visitFunctionCall(node, context);
   }
 
   visitMethodCall(node: e.MethodCall, context: any) {
-    this.addFailureAt(node.span.start, node.span.end - node.span.start, Rule.FAILURE_STRING);
+    this.addFailureFromStartToEnd(node.span.start, node.span.end, Rule.FAILURE_STRING);
 
     super.visitMethodCall(node, context);
   }

--- a/src/pipeImpureRule.ts
+++ b/src/pipeImpureRule.ts
@@ -42,15 +42,9 @@ export class ClassMetadataWalker extends NgWalker {
   }
 
   private validateProperty(className: string, property: any) {
-    let propValue: string = property.initializer.getText();
+    const propValue = property.initializer.getText();
     if (propValue === 'false') {
-      this.addFailure(
-        this.createFailure(property.getStart(), property.getWidth(), sprintf.apply(this, this.createFailureArray(className)))
-      );
+      this.addFailureAtNode(property, sprintf(Rule.FAILURE, className));
     }
-  }
-
-  private createFailureArray(className: string): Array<string> {
-    return [Rule.FAILURE, className];
   }
 }

--- a/src/pipeNamingRule.ts
+++ b/src/pipeNamingRule.ts
@@ -98,21 +98,19 @@ export class ClassMetadataWalker extends NgWalker {
   private validateProperty(className: string, property: ts.Node) {
     const init = (<ts.PropertyAssignment>property).initializer;
     if (init && (<ts.StringLiteral>init).text) {
-      let propName: string = (<ts.StringLiteral>init).text;
-      let isValidName: boolean = this.rule.validateName(propName);
-      let isValidPrefix: boolean = this.rule.hasPrefix ? this.rule.validatePrefix(propName) : true;
+      const propName = (<ts.StringLiteral>init).text;
+      const isValidName = this.rule.validateName(propName);
+      const isValidPrefix = this.rule.hasPrefix ? this.rule.validatePrefix(propName) : true;
       if (!isValidName || !isValidPrefix) {
-        this.addFailure(
-          this.createFailure(property.getStart(), property.getWidth(), sprintf.apply(this, this.createFailureArray(className, propName)))
-        );
+        this.addFailureAtNode(property, this.getFailureMessage(className, propName));
       }
     }
   }
 
-  private createFailureArray(className: string, pipeName: string): Array<string> {
+  private getFailureMessage(className: string, pipeName: string): string {
     if (this.rule.hasPrefix) {
-      return [Rule.FAILURE_WITH_PREFIX, className, this.rule.prefix, pipeName];
+      return sprintf(Rule.FAILURE_WITH_PREFIX, className, this.rule.prefix, pipeName);
     }
-    return [Rule.FAILURE_WITHOUT_PREFIX, className, pipeName];
+    return sprintf(Rule.FAILURE_WITHOUT_PREFIX, className, pipeName);
   }
 }

--- a/src/propertyDecoratorBase.ts
+++ b/src/propertyDecoratorBase.ts
@@ -53,11 +53,8 @@ class DirectiveMetadataWalker extends Lint.RuleWalker {
 
   private validateProperty(className: string, decoratorName: string, arg: ts.ObjectLiteralExpression) {
     if (arg.kind === SyntaxKind.current().ObjectLiteralExpression) {
-      (<ts.ObjectLiteralExpression>arg).properties.filter(prop => (<any>prop.name).text === this.config.propertyName).forEach(prop => {
-        let p = <any>prop;
-        this.addFailure(
-          this.createFailure(p.getStart(), p.getWidth(), UsePropertyDecorator.formatFailureString(this.config, decoratorName, className))
-        );
+      arg.properties.filter(prop => prop.name.getText() === this.config.propertyName).forEach(prop => {
+        this.addFailureAtNode(prop, UsePropertyDecorator.formatFailureString(this.config, decoratorName, className));
       });
     }
   }

--- a/src/selectorNameBase.ts
+++ b/src/selectorNameBase.ts
@@ -130,17 +130,17 @@ export class SelectorValidatorWalker extends Lint.RuleWalker {
           const selectors: compiler.CssSelector[] = this.extractMainSelector(i);
           if (!this.rule.validateType(selectors)) {
             let error = sprintf(this.rule.getTypeFailure(), className, this.rule.getOptions().ruleArguments[0]);
-            this.addFailure(this.createFailure(i.getStart(), i.getWidth(), error));
+            this.addFailureAtNode(i, error);
           } else if (!this.rule.validateStyle(selectors)) {
             let name = this.rule.getOptions().ruleArguments[2];
             if (name === 'kebab-case') {
               name += ' and include dash';
             }
             let error = sprintf(this.rule.getStyleFailure(), className, name);
-            this.addFailure(this.createFailure(i.getStart(), i.getWidth(), error));
+            this.addFailureAtNode(i, error);
           } else if (!this.rule.validatePrefix(selectors)) {
             let error = sprintf(this.rule.getPrefixFailure(this.rule.prefixes), className, this.rule.prefixes.join(', '));
-            this.addFailure(this.createFailure(i.getStart(), i.getWidth(), error));
+            this.addFailureAtNode(i, error);
           }
         });
     }

--- a/src/useLifeCycleInterfaceRule.ts
+++ b/src/useLifeCycleInterfaceRule.ts
@@ -61,28 +61,21 @@ export class ClassMetadataWalker extends Lint.RuleWalker {
     return interfaces;
   }
 
-  private validateMethods(methods: any[], interfaces: string[], className: string) {
+  private validateMethods(methods: ts.ClassElement[], interfaces: string[], className: string) {
     methods.forEach(m => {
-      let n = (<any>m.name).text;
-      if (n && this.isMethodValidHook(m, interfaces)) {
-        let hookName = n.substr(2, n.lenght);
-        this.addFailure(
-          this.createFailure(
-            m.name.getStart(),
-            m.name.getWidth(),
-            sprintf(Rule.FAILURE_STRING, hookName, Rule.HOOKS_PREFIX + hookName, className)
-          )
-        );
+      const methodName = m.name.getText();
+      if (methodName && this.isMethodValidHook(methodName, interfaces)) {
+        const hookName = methodName.slice(2);
+        this.addFailureAtNode(m.name, sprintf(Rule.FAILURE_STRING, hookName, Rule.HOOKS_PREFIX + hookName, className));
       }
     });
   }
 
-  private isMethodValidHook(m: any, interfaces: string[]): boolean {
-    let n = (<any>m.name).text;
-    let isNg: boolean = n.substr(0, 2) === Rule.HOOKS_PREFIX;
-    let hookName = n.substr(2, n.lenght);
-    let isHook = Rule.LIFE_CYCLE_HOOKS_NAMES.indexOf(hookName) !== -1;
-    let isNotIn: boolean = interfaces.indexOf(hookName) === -1;
+  private isMethodValidHook(methodName: string, interfaces: string[]): boolean {
+    const isNg = methodName.substr(0, 2) === Rule.HOOKS_PREFIX;
+    const hookName = methodName.slice(2);
+    const isHook = Rule.LIFE_CYCLE_HOOKS_NAMES.indexOf(hookName) !== -1;
+    const isNotIn = interfaces.indexOf(hookName) === -1;
     return isNg && isHook && isNotIn;
   }
 }

--- a/src/usePipeDecoratorRule.ts
+++ b/src/usePipeDecoratorRule.ts
@@ -33,13 +33,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 export class ClassMetadataWalker extends Lint.RuleWalker {
   visitClassDeclaration(node: ts.ClassDeclaration) {
     if (this.hasIPipeTransform(node)) {
-      const decorators = maybeNodeArray(<ts.NodeArray<any>>node.decorators);
+      const decorators = maybeNodeArray(node.decorators);
       const className: string = node.name.text;
       const pipes: Array<string> = decorators
         .map(d => (<any>d.expression).text || ((<any>d.expression).expression || {}).text)
         .filter(t => t === 'Pipe');
       if (pipes.length === 0) {
-        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), sprintf.apply(this, [Rule.FAILURE, className])));
+        this.addFailureAtNode(node, sprintf(Rule.FAILURE, className));
       }
     }
     super.visitClassDeclaration(node);

--- a/src/usePipeTransformInterfaceRule.ts
+++ b/src/usePipeTransformInterfaceRule.ts
@@ -39,7 +39,7 @@ export class ClassMetadataWalker extends Lint.RuleWalker {
       if (pipes.length !== 0) {
         let className: string = node.name.text;
         if (!this.hasIPipeTransform(node)) {
-          this.addFailure(this.createFailure(node.getStart(), node.getWidth(), sprintf.apply(this, [Rule.FAILURE, className])));
+          this.addFailureAtNode(node, sprintf(Rule.FAILURE, className));
         }
       }
     }

--- a/src/util/ngVersion.ts
+++ b/src/util/ngVersion.ts
@@ -1,4 +1,4 @@
-import { Version, VERSION } from '@angular/core';
+import { VERSION } from '@angular/core';
 import { SemVerDSL as DSL, ISemVerDSL } from 'semver-dsl';
 
 export const SemVerDSL: ISemVerDSL = DSL(VERSION.full);

--- a/src/walkerFactory/walkerFactory.ts
+++ b/src/walkerFactory/walkerFactory.ts
@@ -33,7 +33,7 @@ class NgComponentWalkerBuilder implements WalkerBuilder<'NgComponent'> {
     const e = class extends NgWalker {
       visitNgComponent(meta: ComponentMetadata) {
         self._where(meta).fmap(failure => {
-          this.addFailure(this.createFailure(failure.node.getStart(), failure.node.getWidth(), failure.message));
+          this.addFailureAtNode(failure.node, failure.message);
         });
         super.visitNgComponent(meta);
       }

--- a/src/walkerFactory/walkerFn.ts
+++ b/src/walkerFactory/walkerFn.ts
@@ -39,7 +39,7 @@ export function all(...validators: Validator[]): F2<ts.SourceFile, IOptions, NgW
       visitNgComponent(meta: ComponentMetadata) {
         validators.forEach(v => {
           if (v.kind === 'NgComponent') {
-            v.validate(meta, this.getOptions()).fmap(failures => failures.forEach(f => this.failed(f)));
+            v.validate(meta, this.getOptions()).fmap(failures => failures.forEach(f => this.generateFailure(f)));
           }
         });
         super.visitNgComponent(meta);
@@ -48,14 +48,14 @@ export function all(...validators: Validator[]): F2<ts.SourceFile, IOptions, NgW
       visitNode(node: ts.Node) {
         validators.forEach(v => {
           if (v.kind === 'Node') {
-            v.validate(node, this.getOptions()).fmap(failures => failures.forEach(f => this.failed(f)));
+            v.validate(node, this.getOptions()).fmap(failures => failures.forEach(f => this.generateFailure(f)));
           }
         });
         super.visitNode(node);
       }
 
-      private failed(failure: Failure) {
-        this.addFailure(this.createFailure(failure.node.getStart(), failure.node.getWidth(), failure.message));
+      private generateFailure(failure: Failure) {
+        this.addFailureAtNode(failure.node, failure.message);
       }
     };
     return new e(sourceFile, options);

--- a/test/angular/sourceMappingVisitor.spec.ts
+++ b/test/angular/sourceMappingVisitor.spec.ts
@@ -1,9 +1,9 @@
 import * as ts from 'typescript';
 import chai = require('chai');
-
-import { getDecoratorPropertyInitializer } from '../../src/util/utils';
-import { SourceMappingVisitor } from '../../src/angular/sourceMappingVisitor';
 import { renderSync } from 'node-sass';
+
+import { SourceMappingVisitor } from '../../src/angular/sourceMappingVisitor';
+import { getDecoratorPropertyInitializer } from '../../src/util/utils';
 
 const getAst = (code: string, file = 'file.ts') => {
   return ts.createSourceFile(file, code, ts.ScriptTarget.ES2015, true);
@@ -37,8 +37,8 @@ describe('SourceMappingVisitor', () => {
       ast,
       {
         disabledIntervals: null,
-        ruleName: 'foo',
         ruleArguments: [],
+        ruleName: 'foo',
         ruleSeverity: 'warning'
       },
       {
@@ -48,7 +48,8 @@ describe('SourceMappingVisitor', () => {
       },
       styleNode.getStart() + 1
     );
-    const failure = visitor.createFailure(0, 3, 'bar');
+    visitor.addFailureAt(0, 3, 'bar');
+    const failure = visitor.getFailures()[0];
     chai.expect(failure.getStartPosition().getPosition()).eq(34);
     chai.expect(failure.getEndPosition().getPosition()).eq(38);
   });

--- a/test/noUnusedCssRule.spec.ts
+++ b/test/noUnusedCssRule.spec.ts
@@ -778,7 +778,7 @@ describe('no-unused-css', () => {
       });
       const code = res.css.toString();
       const base64Map = code.match(/\/\*(.*?)\*\//)[1].replace('# sourceMappingURL=data:application/json;base64,', '');
-      const map = JSON.parse(new Buffer(base64Map, 'base64').toString('ascii'));
+      const map = JSON.parse(Buffer.from(base64Map, 'base64').toString('ascii'));
       return { code, source, map };
     };
 
@@ -882,7 +882,7 @@ describe('no-unused-css', () => {
         });
         const code = res.css.toString();
         const base64Map = code.match(/\/\*(.*?)\*\//)[1].replace('# sourceMappingURL=data:application/json;base64,', '');
-        const map = JSON.parse(new Buffer(base64Map, 'base64').toString('ascii'));
+        const map = JSON.parse(Buffer.from(base64Map, 'base64').toString('ascii'));
         return { code, source, map };
       };
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "class-name": true,
+    "deprecation": true,
     "member-ordering": [
       true,
       {


### PR DESCRIPTION
This:

- Adds `deprecation` rule to the `tslint.json`;
- Replaces all usages of deprecated methods (in majority `tslint` methods);