### PR TITLE
chore: add deprecation message to 'pipe-naming' rule

### DIFF
--- a/src/pipeNamingRule.ts
+++ b/src/pipeNamingRule.ts
@@ -8,6 +8,7 @@ import { IOptions } from 'tslint';
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {
+    deprecationMessage: 'You can name your pipes only camelCase. If you try to use snake-case then your application will not compile.',
     ruleName: 'pipe-naming',
     type: 'style',
     description: 'Enforce consistent case and prefix for pipes.',


### PR DESCRIPTION
Once someone try to use this _deprecated_ rule, it'll show a warning like:

> pipe-naming is deprecated. Message here

<hr>

Not sure if it's the best message, but I've picked it in https://github.com/mgechev/codelyzer/issues/519#issuecomment-366785640.