### PR TITLE
docs: remove option examples deprecated usage

### DIFF
--- a/src/componentSelectorRule.ts
+++ b/src/componentSelectorRule.ts
@@ -1,36 +1,34 @@
+import { IRuleMetadata, Utils } from 'tslint/lib';
 import { SelectorRule } from './selectorNameBase';
-import * as Lint from 'tslint';
+
+const OPTION_ATTRIBUTE = 'attribute';
+const OPTION_ELEMENT = 'element';
+const OPTION_CAMEL_CASE = 'camelCase';
+const OPTION_KEBAB_CASE = 'kebab-case';
 
 export class Rule extends SelectorRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'component-selector',
-    type: 'style',
+  static readonly metadata: IRuleMetadata = {
     description: 'Component selectors should follow given naming rules.',
     descriptionDetails:
       'See more at https://angular.io/styleguide#style-02-07, https://angular.io/styleguide#style-05-02, ' +
       'and https://angular.io/styleguide#style-05-03.',
-    rationale: Lint.Utils.dedent`
-    * Consistent conventions make it easy to quickly identify and reference assets of different types.
-    * Makes it easier to promote and share the component in other apps.
-    * Components are easy to identify in the DOM.
-    * Keeps the element names consistent with the specification for Custom Elements.
-    * Components have templates containing HTML and optional Angular template syntax.
-        * They display content. Developers place components on the page as they would native HTML elements and WebComponents.
-    * It is easier to recognize that a symbol is a component by looking at the template's HTML.
-    `,
+    optionExamples: [
+      [true, OPTION_ELEMENT, 'my-prefix', OPTION_KEBAB_CASE],
+      [true, OPTION_ELEMENT, ['ng', 'ngx'], OPTION_KEBAB_CASE],
+      [true, OPTION_ATTRIBUTE, 'myPrefix', OPTION_CAMEL_CASE]
+    ],
     options: {
-      type: 'array',
       items: [
         {
-          enum: ['element', 'attribute']
+          enum: [OPTION_ATTRIBUTE, OPTION_ELEMENT]
         },
         {
           oneOf: [
             {
-              type: 'array',
               items: {
                 type: 'string'
-              }
+              },
+              type: 'array'
             },
             {
               type: 'string'
@@ -38,39 +36,59 @@ export class Rule extends SelectorRule {
           ]
         },
         {
-          enum: ['kebab-case', 'camelCase']
+          enum: [OPTION_CAMEL_CASE, OPTION_KEBAB_CASE]
         }
       ],
-      minItems: 3,
-      maxItems: 3
+      maxLength: 3,
+      minLength: 3,
+      type: 'array'
     },
-    optionExamples: [
-      '["element", "my-prefix", "kebab-case"]',
-      '["element", ["ng", "ngx"], "kebab-case"]',
-      '["attribute", "myPrefix", "camelCase"]'
-    ],
-    optionsDescription: Lint.Utils.dedent`
-    Options accept three obligatory items as an array:
-
-    1. \`"element"\` or \`"attribute"\` forces components either to be elements or attributes.
-    2. A single prefix (string) or array of prefixes (strings) which have to be used in component selectors.
-    3. \`"kebab-case"\` or \`"camelCase"\` allows you to pick a case.
+    optionsDescription: Utils.dedent`
+      Options accept three obligatory items as an array:
+      1. \`${OPTION_ELEMENT}\` or \`${OPTION_ATTRIBUTE}\` forces components either to be elements or attributes.
+      2. A single prefix (string) or array of prefixes (strings) which have to be used in component selectors.
+      3. \`${OPTION_KEBAB_CASE}\` or \`${OPTION_CAMEL_CASE}\` allows you to pick a case.
     `,
+    rationale: Utils.dedent`
+      * Consistent conventions make it easy to quickly identify and reference assets of different types.
+      * Makes it easier to promote and share the component in other apps.
+      * Components are easy to identify in the DOM.
+      * Keeps the element names consistent with the specification for Custom Elements.
+      * Components have templates containing HTML and optional Angular template syntax.
+      * They display content. Developers place components on the page as they would native HTML elements and WebComponents.
+      * It is easier to recognize that a symbol is a component by looking at the template's HTML.
+    `,
+    ruleName: 'component-selector',
+    type: 'style',
     typescriptOnly: true
   };
 
-  public handleType = 'Component';
-  public getTypeFailure(): any {
-    return 'The selector of the component "%s" should be used as %s (https://angular.io/styleguide#style-05-03)';
-  }
-  public getStyleFailure(): any {
-    return 'The selector of the component "%s" should be named %s (https://angular.io/styleguide#style-05-02)';
-  }
-  getPrefixFailure(prefixes: string[]): any {
+  handleType = 'Component';
+
+  getPrefixFailure(prefixes: string[]): string {
     if (prefixes.length === 1) {
       return 'The selector of the component "%s" should have prefix "%s" (https://angular.io/styleguide#style-02-07)';
     } else {
       return 'The selector of the component "%s" should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-07)';
     }
+  }
+
+  getStyleFailure(): string {
+    return 'The selector of the component "%s" should be named %s (https://angular.io/styleguide#style-05-02)';
+  }
+
+  getTypeFailure(): string {
+    return 'The selector of the component "%s" should be used as %s (https://angular.io/styleguide#style-05-03)';
+  }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { maxLength, minLength }
+      }
+    } = Rule;
+    const { length } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength && length <= maxLength;
   }
 }

--- a/src/contextualLifeCycleRule.ts
+++ b/src/contextualLifeCycleRule.ts
@@ -5,18 +5,18 @@ import { ComponentMetadata, DirectiveMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  static metadata: Lint.IRuleMetadata = {
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Ensure that classes use allowed life cycle method in its body.',
     options: null,
     optionsDescription: 'Not configurable.',
-    rationale: `Some life cycle methods can only be used in certain class types.
-    For example, ngOnInit() hook method should not be used in an @Injectable class.`,
+    rationale:
+      'Some life cycle methods can only be used in certain class types.For example, ngOnInit() hook method should not be used in an @Injectable class.',
     ruleName: 'contextual-life-cycle',
     type: 'functionality',
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = 'In the class "%s" which have the "%s" decorator, the ' +
+  static readonly FAILURE_STRING = 'In the class "%s" which have the "%s" decorator, the ' +
   '"%s" hook method is not allowed. ' +
   'Please, drop it.';
 

--- a/src/decoratorNotAllowedRule.ts
+++ b/src/decoratorNotAllowedRule.ts
@@ -1,26 +1,26 @@
+import { vsprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { vsprintf } from 'sprintf-js';
-import { NgWalker } from './angular/ngWalker';
 import { ComponentMetadata, DirectiveMetadata } from './angular/metadata';
+import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'decorator-not-allowed',
-    type: 'functionality',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Ensure that classes use allowed decorator in its body.',
-    rationale: `Some decorators can only be used in certain class types.
-    For example, an @Input should not be used in an @Injectable class.`,
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale:
+      'Some decorators can only be used in certain class types. For example, an @Input should not be used in an @Injectable class.',
+    ruleName: 'decorator-not-allowed',
+    type: 'functionality',
     typescriptOnly: true
   };
 
-  static INJECTABLE_FAILURE_STRING = 'In the class "%s" which have the "%s" decorator, the ' +
+  static readonly FAILURE_STRING = 'In the class "%s" which have the "%s" decorator, the ' +
   '"%s" decorator is not allowed. ' +
   'Please, drop it.';
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this.getOptions()));
   }
 }
@@ -107,6 +107,6 @@ export class ClassMetadataWalker extends NgWalker {
   }
 
   private generateFailure(property: ts.Node, ...failureConfig: string[]) {
-    this.addFailureAtNode(property, vsprintf(Rule.INJECTABLE_FAILURE_STRING, failureConfig));
+    this.addFailureAtNode(property, vsprintf(Rule.FAILURE_STRING, failureConfig));
   }
 }

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -1,6 +1,6 @@
+import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
 import { NgWalker } from './angular/ngWalker';
 
 import { DirectiveMetadata } from './angular/metadata';
@@ -18,30 +18,31 @@ const getInterfaceName = (t: any): string => {
 const ValidatorSuffix = 'Validator';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'directive-class-suffix',
-    type: 'style',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Classes decorated with @Directive must have suffix "Directive" (or custom) in their name.',
     descriptionDetails: 'See more at https://angular.io/styleguide#style-02-03.',
-    rationale: 'Consistent conventions make it easy to quickly identify and reference assets of different types.',
+    optionExamples: [true, [true, 'Directive', 'MySuffix']],
     options: {
-      type: 'array',
       items: {
         type: 'string'
-      }
+      },
+      minLength: 0,
+      type: 'array'
     },
-    optionExamples: ['true', '[true, "Directive", "MySuffix"]'],
     optionsDescription: 'Supply a list of allowed component suffixes. Defaults to "Directive".',
+    rationale: 'Consistent conventions make it easy to quickly identify and reference assets of different types.',
+    ruleName: 'directive-class-suffix',
+    type: 'style',
     typescriptOnly: true
   };
 
-  static FAILURE: string = 'The name of the class %s should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
+  static readonly FAILURE_STRING = 'The name of the class %s should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
 
   static validate(className: string, suffixes: string[]): boolean {
     return suffixes.some(s => className.endsWith(s));
   }
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this.getOptions()));
   }
 }
@@ -66,7 +67,7 @@ export class ClassMetadataWalker extends NgWalker {
       }
     }
     if (!Rule.validate(className, suffixes)) {
-      this.addFailureAtNode(name, sprintf(Rule.FAILURE, className, suffixes.join(', ')));
+      this.addFailureAtNode(name, sprintf(Rule.FAILURE_STRING, className, suffixes.join(', ')));
     }
     super.visitNgDirective(metadata);
   }

--- a/src/directiveSelectorRule.ts
+++ b/src/directiveSelectorRule.ts
@@ -1,31 +1,32 @@
+import { IRuleMetadata, Utils } from 'tslint/lib';
 import { SelectorRule } from './selectorNameBase';
-import * as Lint from 'tslint';
+
+const OPTION_ATTRIBUTE = 'attribute';
+const OPTION_ELEMENT = 'element';
+const OPTION_CAMEL_CASE = 'camelCase';
+const OPTION_KEBAB_CASE = 'kebab-case';
 
 export class Rule extends SelectorRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'directive-selector',
-    type: 'style',
+  static readonly metadata: IRuleMetadata = {
     description: 'Directive selectors should follow given naming rules.',
-    descriptionDetails: 'See more at https://angular.io/styleguide#style-02-06 ' + 'and https://angular.io/styleguide#style-02-08.',
-    rationale: Lint.Utils.dedent`
-    * Consistent conventions make it easy to quickly identify and reference assets of different types.
-    * Makes it easier to promote and share the directive in other apps.
-    * Directives are easy to identify in the DOM.
-    * It is easier to recognize that a symbol is a directive by looking at the template's HTML.
-    `,
+    descriptionDetails: 'See more at https://angular.io/styleguide#style-02-06 and https://angular.io/styleguide#style-02-08.',
+    optionExamples: [
+      [true, OPTION_ELEMENT, 'my-prefix', OPTION_KEBAB_CASE],
+      [true, OPTION_ELEMENT, ['ng', 'ngx'], OPTION_KEBAB_CASE],
+      [true, OPTION_ATTRIBUTE, 'myPrefix', OPTION_CAMEL_CASE]
+    ],
     options: {
-      type: 'array',
       items: [
         {
-          enum: ['element', 'attribute']
+          enum: [OPTION_ATTRIBUTE, OPTION_ELEMENT]
         },
         {
           oneOf: [
             {
-              type: 'array',
               items: {
                 type: 'string'
-              }
+              },
+              type: 'array'
             },
             {
               type: 'string'
@@ -33,39 +34,56 @@ export class Rule extends SelectorRule {
           ]
         },
         {
-          enum: ['kebab-case', 'camelCase']
+          enum: [OPTION_CAMEL_CASE, OPTION_KEBAB_CASE]
         }
       ],
-      minItems: 3,
-      maxItems: 3
+      maxLength: 3,
+      minLength: 3,
+      type: 'array'
     },
-    optionExamples: [
-      '["element", "my-prefix", "kebab-case"]',
-      '["element", ["ng", "ngx"], "kebab-case"]',
-      '["attribute", "myPrefix", "camelCase"]'
-    ],
-    optionsDescription: Lint.Utils.dedent`
-    Options accept three obligatory items as an array:
-
-    1. \`"element"\` or \`"attribute"\` forces components either to be elements or attributes.
-    2. A single prefix (string) or array of prefixes (strings) which have to be used in directive selectors.
-    3. \`"kebab-case"\` or \`"camelCase"\` allows you to pick a case.
+    optionsDescription: Utils.dedent`
+      Options accept three obligatory items as an array:
+      1. \`${OPTION_ELEMENT}\` or \`${OPTION_ATTRIBUTE}\` forces directives either to be elements or attributes.
+      2. A single prefix (string) or array of prefixes (strings) which have to be used in directive selectors.
+      3. \`${OPTION_KEBAB_CASE}\` or \`${OPTION_CAMEL_CASE}\` allows you to pick a case.
     `,
+    rationale: Utils.dedent`
+      * Consistent conventions make it easy to quickly identify and reference assets of different types.
+      * Makes it easier to promote and share the directive in other apps.
+      * Directives are easy to identify in the DOM.
+      * It is easier to recognize that a symbol is a directive by looking at the template's HTML.
+    `,
+    ruleName: 'directive-selector',
+    type: 'style',
     typescriptOnly: true
   };
 
-  public handleType = 'Directive';
-  public getTypeFailure(): string {
-    return 'The selector of the directive "%s" should be used as %s (https://angular.io/styleguide#style-02-06)';
-  }
-  public getStyleFailure(): string {
-    return 'The selector of the directive "%s" should be named %s (https://angular.io/styleguide#style-02-06)';
-  }
+  handleType = 'Directive';
+
   getPrefixFailure(prefixes: string[]): string {
     if (prefixes.length === 1) {
       return 'The selector of the directive "%s" should have prefix "%s" (https://angular.io/styleguide#style-02-08)';
     } else {
       return 'The selector of the directive "%s" should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-08)';
     }
+  }
+
+  getStyleFailure(): string {
+    return 'The selector of the directive "%s" should be named %s (https://angular.io/styleguide#style-02-06)';
+  }
+
+  getTypeFailure(): string {
+    return 'The selector of the directive "%s" should be used as %s (https://angular.io/styleguide#style-02-06)';
+  }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { maxLength, minLength }
+      }
+    } = Rule;
+    const { length } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength && length <= maxLength;
   }
 }

--- a/src/importDestructuringSpacingRule.ts
+++ b/src/importDestructuringSpacingRule.ts
@@ -41,7 +41,7 @@ class ImportDestructuringSpacingWalker extends RuleWalker {
   private getFix(node: NamedImports, totalLeadingSpaces: number, totalTrailingSpaces: number): Fix {
     const nodeStartPos = node.getStart();
     const nodeEndPos = node.getEnd();
-    let fix: Fix = [];
+    const fix: Fix = [];
 
     if (totalLeadingSpaces === 0) {
       fix.push(Replacement.appendText(nodeStartPos + 1, ' '));

--- a/src/maxInlineDeclarationsRule.ts
+++ b/src/maxInlineDeclarationsRule.ts
@@ -47,6 +47,17 @@ export class Rule extends Rules.AbstractRule {
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new MaxInlineDeclarationsValidator(sourceFile, this.getOptions()));
   }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { maxLength, minLength }
+      }
+    } = Rule;
+    const { length } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength && length <= maxLength;
+  }
 }
 
 type PropertyType = 'styles' | 'template';

--- a/src/noInputPrefixRule.ts
+++ b/src/noInputPrefixRule.ts
@@ -1,5 +1,5 @@
 import { sprintf } from 'sprintf-js';
-import { IOptions, IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
+import { IOptions, IRuleMetadata, RuleFailure, Rules, Utils } from 'tslint/lib';
 import { Decorator, PropertyDeclaration, SourceFile } from 'typescript';
 
 import { NgWalker } from './angular/ngWalker';
@@ -7,14 +7,20 @@ import { NgWalker } from './angular/ngWalker';
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
     description: 'Input names should not be prefixed by the configured disallowed prefixes.',
-    optionExamples: ['[true, "can", "is", "should"]'],
+    optionExamples: [[true, 'can', 'is', 'should']],
     options: {
-      items: [{ type: 'string' }],
+      items: [
+        {
+          type: 'string'
+        }
+      ],
+      minLength: 1,
       type: 'array'
     },
     optionsDescription: 'Options accept a string array of disallowed input prefixes.',
-    rationale: `HTML attributes are not prefixed. It's considered best not to prefix Inputs.
-    * Example: 'enabled' is prefered over 'isEnabled'.
+    rationale: Utils.dedent`
+      HTML attributes are not prefixed. It's considered best not to prefix Inputs.
+      * Example: 'enabled' is prefered over 'isEnabled'.
     `,
     ruleName: 'no-input-prefix',
     type: 'maintainability',
@@ -25,6 +31,17 @@ export class Rule extends Rules.AbstractRule {
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new NoInputPrefixWalker(sourceFile, this.getOptions()));
+  }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { minLength }
+      }
+    } = Rule;
+    const { length } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength;
   }
 }
 

--- a/src/noLifeCycleCallRule.ts
+++ b/src/noLifeCycleCallRule.ts
@@ -3,7 +3,7 @@ import * as ts from 'typescript';
 import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  static metadata: Lint.IRuleMetadata = {
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Disallows explicit calls to life cycle hooks.',
     options: null,
     optionsDescription: 'Not configurable.',
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = 'Avoid explicit calls to life cycle hooks.';
+  static readonly FAILURE_STRING = 'Avoid explicit calls to life cycle hooks.';
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new ExpressionCallMetadataWalker(sourceFile, this.getOptions()));

--- a/src/noOutputNamedAfterStandardEventRule.ts
+++ b/src/noOutputNamedAfterStandardEventRule.ts
@@ -1,22 +1,22 @@
+import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
 import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'no-output-named-after-standard-event',
-    type: 'maintainability',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Disallows naming directive outputs after a standard DOM event.',
-    rationale: 'Listeners subscribed to an output with such a name will also be invoked when the native event is raised.',
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale: 'Listeners subscribed to an output with such a name will also be invoked when the native event is raised.',
+    ruleName: 'no-output-named-after-standard-event',
+    type: 'maintainability',
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = 'In the class "%s", the output ' + 'property "%s" should not be named or renamed after a standard event';
+  static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be named or renamed after a standard event';
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new OutputMetadataWalker(sourceFile, this.getOptions()));
   }
 }

--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -1,24 +1,24 @@
+import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
 import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'no-output-on-prefix',
-    type: 'maintainability',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Name events without the prefix on.',
     descriptionDetails: 'See more at https://angular.io/guide/styleguide#dont-prefix-output-properties.',
-    rationale: `Angular allows for an alternative syntax on-*. If the event itself was prefixed with on
-     this would result in an on-onEvent binding expression.`,
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale:
+      'Angular allows for an alternative syntax on-*. If the event itself was prefixed with on this would result in an on-onEvent binding expression.',
+    ruleName: 'no-output-on-prefix',
+    type: 'maintainability',
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = 'In the class "%s", the output ' + 'property "%s" should not be prefixed with on';
+  static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be prefixed with on';
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new OutputWalker(sourceFile, this.getOptions()));
   }
 }

--- a/src/noTemplateCallExpressionRule.ts
+++ b/src/noTemplateCallExpressionRule.ts
@@ -1,22 +1,22 @@
+import * as e from '@angular/compiler/src/expression_parser/ast';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 import { RecursiveAngularExpressionVisitor } from './angular/templates/recursiveAngularExpressionVisitor';
-import * as e from '@angular/compiler/src/expression_parser/ast';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'no-template-call-expression',
-    type: 'functionality',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Call expressions are not allowed in templates except in output handlers.',
-    rationale: 'The change detector will call functions used in templates very often. Use an observable instead.',
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale: 'The change detector will call functions used in templates very often. Use an observable instead.',
+    ruleName: 'no-template-call-expression',
+    type: 'maintainability',
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = 'Call expressions are not allowed in templates except in output handlers';
+  static readonly FAILURE_STRING = 'Call expressions are not allowed in templates except in output handlers';
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     const walkerConfig: NgWalkerConfig = {

--- a/src/pipeNamingRule.ts
+++ b/src/pipeNamingRule.ts
@@ -1,67 +1,92 @@
+import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
-import SyntaxKind = require('./util/syntaxKind');
 import { NgWalker } from './angular/ngWalker';
 import { SelectorValidator } from './util/selectorValidator';
-import { IOptions } from 'tslint';
+
+const OPTION_ATTRIBUTE = 'attribute';
+const OPTION_ELEMENT = 'element';
+const OPTION_CAMEL_CASE = 'camelCase';
+const OPTION_KEBAB_CASE = 'kebab-case';
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    deprecationMessage: 'You can name your pipes only camelCase. If you try to use snake-case then your application will not compile.',
+  static readonly metadata: Lint.IRuleMetadata = {
+    deprecationMessage: `You can name your pipes only ${OPTION_CAMEL_CASE}. If you try to use snake-case then your application will not compile.`,
+    description: 'Enforce consistent case and prefix for pipes.',
+    optionExamples: [
+      [true, OPTION_CAMEL_CASE, 'myPrefix'],
+      [true, OPTION_CAMEL_CASE, 'myPrefix', 'myOtherPrefix'],
+      [true, OPTION_KEBAB_CASE, 'my-prefix']
+    ],
+    options: {
+      items: [
+        {
+          enum: [OPTION_KEBAB_CASE, OPTION_ATTRIBUTE]
+        },
+        {
+          type: 'string'
+        }
+      ],
+      minLength: 1,
+      type: 'array'
+    },
+    optionsDescription: Lint.Utils.dedent`
+      * The first item in the array is \`${OPTION_CAMEL_CASE}\` or \`${OPTION_KEBAB_CASE}\`, which allows you to pick a case.
+      * The rest of the arguments are supported prefixes (given as strings). They are optional.
+    `,
+    rationale: 'Consistent conventions make it easy to quickly identify and reference assets of different types.',
     ruleName: 'pipe-naming',
     type: 'style',
-    description: 'Enforce consistent case and prefix for pipes.',
-    rationale: 'Consistent conventions make it easy to quickly identify and reference assets of different types.',
-    options: {
-      type: 'array',
-      items: [{ enum: ['kebab-case', 'attribute'] }, { type: 'string' }],
-      minItems: 1
-    },
-    optionExamples: ['["camelCase", "myPrefix"]', '["camelCase", "myPrefix", "myOtherPrefix"]', '["kebab-case", "my-prefix"]'],
-    optionsDescription: Lint.Utils.dedent`
-    * The first item in the array is \`"kebab-case"\` or \`"camelCase"\`, which allows you to pick a case.
-    * The rest of the arguments are supported prefixes (given as strings). They are optional.`,
     typescriptOnly: true
   };
 
-  static FAILURE_WITHOUT_PREFIX = 'The name of the Pipe decorator of class %s should' + ' be named camelCase, however its value is "%s"';
+  static FAILURE_WITHOUT_PREFIX = `The name of the Pipe decorator of class %s should be named ${OPTION_CAMEL_CASE}, however its value is "%s"`;
 
-  static FAILURE_WITH_PREFIX = 'The name of the Pipe decorator of class %s should' +
-  ' be named camelCase with prefix %s, however its value is "%s"';
+  static FAILURE_WITH_PREFIX = `The name of the Pipe decorator of class %s should be named ${OPTION_CAMEL_CASE} with prefix %s, however its value is "%s"`;
 
-  public prefix: string;
-  public hasPrefix: boolean;
+  prefix: string;
+  hasPrefix: boolean;
   private prefixChecker: Function;
   private validator: Function;
 
-  constructor(options: IOptions) {
+  constructor(options: Lint.IOptions) {
     super(options);
 
     let args = options.ruleArguments;
     if (!(args instanceof Array)) {
       args = [args];
     }
-    if (args[0] === 'camelCase') {
+    if (args[0] === OPTION_CAMEL_CASE) {
       this.validator = SelectorValidator.camelCase;
     }
     if (args.length > 1) {
       this.hasPrefix = true;
       let prefixExpression: string = (args.slice(1) || []).join('|');
       this.prefix = (args.slice(1) || []).join(',');
-      this.prefixChecker = SelectorValidator.prefix(prefixExpression, 'camelCase');
+      this.prefixChecker = SelectorValidator.prefix(prefixExpression, OPTION_CAMEL_CASE);
     }
   }
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this));
   }
 
-  public validateName(name: string): boolean {
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { minLength }
+      }
+    } = Rule;
+    const { length } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength;
+  }
+
+  validateName(name: string): boolean {
     return this.validator(name);
   }
 
-  public validatePrefix(prefix: string): boolean {
+  validatePrefix(prefix: string): boolean {
     return this.prefixChecker(prefix);
   }
 }
@@ -79,7 +104,7 @@ export class ClassMetadataWalker extends NgWalker {
 
   private validateProperties(className: string, pipe: ts.Decorator) {
     let argument = this.extractArgument(pipe);
-    if (argument && argument.kind === SyntaxKind.current().ObjectLiteralExpression) {
+    if (argument && argument.kind === ts.SyntaxKind.ObjectLiteralExpression) {
       (<ts.ObjectLiteralExpression>argument).properties
         .filter(n => n.name && (<ts.StringLiteral>n.name).text === 'name')
         .forEach(this.validateProperty.bind(this, className));

--- a/src/templateConditionalComplexityRule.ts
+++ b/src/templateConditionalComplexityRule.ts
@@ -8,12 +8,12 @@ import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVis
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
     description: "The condition complexity shouldn't exceed a rational limit in a template.",
-    optionExamples: ['true', '[true, 4]'],
+    optionExamples: [true, [true, 4]],
     options: {
       items: {
         type: 'string'
       },
-      maxLength: 2,
+      maxLength: 1,
       minLength: 0,
       type: 'array'
     },
@@ -33,6 +33,17 @@ export class Rule extends Rules.AbstractRule {
         templateVisitorCtrl: TemplateConditionalComplexityVisitor
       })
     );
+  }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { maxLength, minLength }
+      }
+    } = Rule;
+    const { length, [0]: maxComplexity } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength && length <= maxLength && (maxComplexity === undefined || maxComplexity > 0);
   }
 }
 

--- a/src/templateCyclomaticComplexityRule.ts
+++ b/src/templateCyclomaticComplexityRule.ts
@@ -9,19 +9,19 @@ export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
     description:
       "Checks cyclomatic complexity against a specified limit. It is a quantitative measure of the number of linearly independent paths through a program's source code",
-    optionExamples: ['true', '[true, 6]'],
+    optionExamples: [true, [true, 6]],
     options: {
       items: {
         type: 'string'
       },
-      maxLength: 2,
+      maxLength: 1,
       minLength: 0,
       type: 'array'
     },
     optionsDescription: 'Determine the maximum number of the cyclomatic complexity.',
     rationale: 'Cyclomatic complexity over some threshold indicates that the logic should be moved outside the template.',
     ruleName: 'template-cyclomatic-complexity',
-    type: 'functionality',
+    type: 'maintainability',
     typescriptOnly: true
   };
 
@@ -34,6 +34,17 @@ export class Rule extends Rules.AbstractRule {
         templateVisitorCtrl: TemplateConditionalComplexityVisitor
       })
     );
+  }
+
+  isEnabled(): boolean {
+    const {
+      metadata: {
+        options: { maxLength, minLength }
+      }
+    } = Rule;
+    const { length, [0]: maxComplexity } = this.ruleArguments;
+
+    return super.isEnabled() && length >= minLength && length <= maxLength && (maxComplexity === undefined || maxComplexity > 0);
   }
 }
 

--- a/src/trackByFunctionRule.ts
+++ b/src/trackByFunctionRule.ts
@@ -11,7 +11,7 @@ export class Rule extends Rules.AbstractRule {
     optionsDescription: 'Not configurable.',
     rationale: "The use of 'trackBy' is considered a good practice.",
     ruleName: 'trackBy-function',
-    type: 'functionality',
+    type: 'maintainability',
     typescriptOnly: true
   };
 

--- a/src/useInputPropertyDecoratorRule.ts
+++ b/src/useInputPropertyDecoratorRule.ts
@@ -1,30 +1,29 @@
 import * as Lint from 'tslint';
-
 import { UsePropertyDecorator } from './propertyDecoratorBase';
-import { IOptions } from 'tslint';
 
 export class Rule extends UsePropertyDecorator {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'use-input-property-decorator',
-    type: 'style',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Use `@Input` decorator rather than the `inputs` property of `@Component` and `@Directive` metadata.',
     descriptionDetails: 'See more at https://angular.io/styleguide#style-05-12.',
-    rationale: Lint.Utils.dedent`
-    * It is easier and more readable to identify which properties in a class are inputs.
-    * If you ever need to rename the property name associated with \`@Input\`, you can modify it in a single place.
-    * The metadata declaration attached to the directive is shorter and thus more readable.
-    * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an input.`,
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale: Lint.Utils.dedent`
+      * It is easier and more readable to identify which properties in a class are inputs.
+      * If you ever need to rename the property name associated with \`@Input\`, you can modify it in a single place.
+      * The metadata declaration attached to the directive is shorter and thus more readable.
+      * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an input.
+    `,
+    ruleName: 'use-input-property-decorator',
+    type: 'style',
     typescriptOnly: true
   };
 
-  constructor(options: IOptions) {
+  constructor(options: Lint.IOptions) {
     super(
       {
         decoratorName: 'Input',
-        propertyName: 'inputs',
-        errorMessage: 'Use the @Input property decorator instead of the inputs property (https://angular.io/styleguide#style-05-12)'
+        errorMessage: 'Use the @Input property decorator instead of the inputs property (https://angular.io/styleguide#style-05-12)',
+        propertyName: 'inputs'
       },
       options
     );

--- a/src/useOutputPropertyDecoratorRule.ts
+++ b/src/useOutputPropertyDecoratorRule.ts
@@ -1,30 +1,29 @@
 import * as Lint from 'tslint';
-
 import { UsePropertyDecorator } from './propertyDecoratorBase';
-import { IOptions } from 'tslint';
 
 export class Rule extends UsePropertyDecorator {
-  public static metadata: Lint.IRuleMetadata = {
-    ruleName: 'use-output-property-decorator',
-    type: 'style',
+  static readonly metadata: Lint.IRuleMetadata = {
     description: 'Use `@Output` decorator rather than the `outputs` property of `@Component` and `@Directive` metadata.',
     descriptionDetails: 'See more at https://angular.io/styleguide#style-05-12.',
-    rationale: Lint.Utils.dedent`
-    * It is easier and more readable to identify which properties in a class are events.
-    * If you ever need to rename the event name associated with \`@Output\`, you can modify it in a single place.
-    * The metadata declaration attached to the directive is shorter and thus more readable.
-    * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an output.`,
     options: null,
     optionsDescription: 'Not configurable.',
+    rationale: Lint.Utils.dedent`
+      * It is easier and more readable to identify which properties in a class are events.
+      * If you ever need to rename the event name associated with \`@Output\`, you can modify it in a single place.
+      * The metadata declaration attached to the directive is shorter and thus more readable.
+      * Placing the decorator on the same line usually makes for shorter code and still easily identifies the property as an output.
+    `,
+    ruleName: 'use-output-property-decorator',
+    type: 'style',
     typescriptOnly: true
   };
 
-  constructor(options: IOptions) {
+  constructor(options: Lint.IOptions) {
     super(
       {
         decoratorName: 'Output',
-        propertyName: 'outputs',
-        errorMessage: 'Use the @Output property decorator instead of the outputs property (https://angular.io/styleguide#style-05-12)'
+        errorMessage: 'Use the @Output property decorator instead of the outputs property (https://angular.io/styleguide#style-05-12)',
+        propertyName: 'outputs'
       },
       options
     );


### PR DESCRIPTION
PR https://github.com/palantir/tslint/pull/2527 deprecated passing an `array` of strings for `optionExamples`.

In addition to this, I've refactored the metadata in general to be more generic as `tslint` does, using `const` variables for `options` and so on.