### PR TITLE
refactor: use type guard instead of unnecessary or incorrect type assertions

### DIFF
--- a/src/angular/config.ts
+++ b/src/angular/config.ts
@@ -35,6 +35,10 @@ export interface DirectiveDeclaration {
 
 let BUILD_TYPE = '<%= BUILD_TYPE %>';
 
+const transform = (code: string, extension: '.css' | '.html', url?: string): { code: string; url?: string } => {
+  return { code: !url || url.endsWith(extension) ? code : '', url };
+};
+
 export const Config: Config = {
   interpolation: ['{{', '}}'],
 
@@ -71,25 +75,13 @@ export const Config: Config = {
     return url;
   },
 
-  transformStyle(code: string, url?: string) {
-    if (!url || url.endsWith('.css')) {
-      return { code, url };
-    }
+  transformStyle: (code: string, url?: string) => transform(code, '.css', url),
 
-    return { code: '', url };
-  },
-
-  transformTemplate(code: string, url?: string) {
-    if (!url || url.endsWith('.html')) {
-      return { code, url };
-    }
-
-    return { code: '', url };
-  }
+  transformTemplate: (code: string, url?: string) => transform(code, '.html', url)
 };
 
 try {
   const root = require('app-root-path');
   const newConfig = require(root.path + '/.codelyzer');
   Object.assign(Config, newConfig);
-} catch (e) {}
+} catch {}

--- a/src/angular/metadata.ts
+++ b/src/angular/metadata.ts
@@ -25,13 +25,22 @@ export interface TemplateMetadata extends PropertyMetadata {
 }
 
 export class DirectiveMetadata {
-  controller!: ts.ClassDeclaration;
-  decorator!: ts.Decorator;
-  selector!: string;
+  constructor(
+    public readonly controller: ts.ClassDeclaration,
+    public readonly decorator: ts.Decorator,
+    public readonly selector?: string
+  ) {}
 }
 
 export class ComponentMetadata extends DirectiveMetadata {
-  animations!: AnimationMetadata[];
-  styles!: StyleMetadata[];
-  template!: TemplateMetadata;
+  constructor(
+    public readonly controller: ts.ClassDeclaration,
+    public readonly decorator: ts.Decorator,
+    public readonly selector?: string,
+    public readonly animations?: (AnimationMetadata | undefined)[],
+    public readonly styles?: (StyleMetadata | undefined)[],
+    public readonly template?: TemplateMetadata
+  ) {
+    super(controller, decorator, selector);
+  }
 }

--- a/src/angular/sourceMappingVisitor.ts
+++ b/src/angular/sourceMappingVisitor.ts
@@ -64,7 +64,7 @@ function computeLineAndCharacterOfPosition(lineStarts: number[], position: numbe
 }
 
 function computeLineStarts(text: string): number[] {
-  const result: number[] = new Array();
+  const result: number[] = [];
   let pos = 0;
   let lineStart = 0;
   while (pos < text.length) {
@@ -95,7 +95,7 @@ export class SourceMappingVisitor extends RuleWalker {
   parentAST: any;
   private consumer: SourceMapConsumer;
 
-  constructor(sourceFile: ts.SourceFile, options: IOptions, protected codeWithMap: CodeWithSourceMap, protected basePosition: number) {
+  constructor(sourceFile: ts.SourceFile, options: IOptions, public codeWithMap: CodeWithSourceMap, protected basePosition: number) {
     super(sourceFile, options);
     if (this.codeWithMap.map) {
       this.consumer = new SourceMapConsumer(this.codeWithMap.map);

--- a/src/angular/styles/cssAst.ts
+++ b/src/angular/styles/cssAst.ts
@@ -106,7 +106,7 @@ export class CssBlockDefinitionRuleAst extends CssBlockRuleAst {
     block: CssBlockAst
   ) {
     super(location, type, block);
-    const firstCssToken: CssToken = query.tokens[0];
+    const firstCssToken = query.tokens[0];
     this.name = new CssToken(firstCssToken.index, firstCssToken.column, firstCssToken.line, CssTokenType.Identifier, this.strValue);
   }
   visit(visitor: CssAstVisitor, context?: any): any {

--- a/src/angular/styles/cssParser.ts
+++ b/src/angular/styles/cssParser.ts
@@ -518,7 +518,7 @@ export class CssParser {
         }
 
         // :host(a, b, c) {
-        this._parseSelectors(innerDelims).forEach((selector, index) => {
+        this._parseSelectors(innerDelims).forEach(selector => {
           innerSelectors.push(selector);
         });
       } else {
@@ -553,7 +553,7 @@ export class CssParser {
     const selectorCssTokens: CssToken[] = [];
     const pseudoSelectors: CssPseudoSelectorAst[] = [];
 
-    let previousToken: CssToken = undefined!;
+    let previousToken: CssToken | null = null!;
 
     const selectorPartDelimiters = delimiters | SPACE_DELIM_FLAG;
     let loopOverSelector = !characterContainsDelimiter(this._scanner!.peek, selectorPartDelimiters);
@@ -736,7 +736,7 @@ export class CssParser {
     const start = this._getScannerIndex();
 
     const tokens: CssToken[] = [];
-    let previous: CssToken = undefined!;
+    let previous: CssToken | null = null!;
     while (!characterContainsDelimiter(this._scanner!.peek, delimiters)) {
       let token: CssToken;
       if (previous != null && previous.type == CssTokenType.Identifier && this._scanner!.peek == chars.$LPAREN) {

--- a/src/angular/templates/basicTemplateAstVisitor.ts
+++ b/src/angular/templates/basicTemplateAstVisitor.ts
@@ -8,7 +8,7 @@ import { ComponentMetadata } from '../metadata';
 import { RecursiveAngularExpressionVisitor } from './recursiveAngularExpressionVisitor';
 import { SourceMappingVisitor } from '../sourceMappingVisitor';
 
-const getExpressionDisplacement = (binding: any) => {
+const getExpressionDisplacement = (binding: ast.TemplateAst) => {
   let attrLen = 0;
   let valLen = 0;
   let totalLength = 0;
@@ -22,9 +22,8 @@ const getExpressionDisplacement = (binding: any) => {
     // the binding type. For event it is 0. (+1 because of the ".")
     let subBindingLen = 0;
     if (binding instanceof ast.BoundElementPropertyAst) {
-      let prop: ast.BoundElementPropertyAst = <ast.BoundElementPropertyAst>binding;
       // The length of the binding type
-      switch (prop.type) {
+      switch (binding.type) {
         case ast.PropertyBindingType.Animation:
           subBindingLen = 'animate'.length + 1;
           break;
@@ -108,7 +107,7 @@ export class BasicTemplateAstVisitor extends SourceMappingVisitor implements ast
     protected templateStart: number,
     private expressionVisitorCtrl: RecursiveAngularExpressionVisitorCtr = RecursiveAngularExpressionVisitor
   ) {
-    super(sourceFile, _originalOptions, context.template.template, templateStart);
+    super(sourceFile, _originalOptions, context.template!.template, templateStart);
   }
 
   visit?(node: ast.TemplateAst, context: any): any {
@@ -148,8 +147,8 @@ export class BasicTemplateAstVisitor extends SourceMappingVisitor implements ast
   }
 
   visitElementProperty(prop: ast.BoundElementPropertyAst, context: any): any {
-    const ast: any = (<e.ASTWithSource>prop.value).ast;
-    ast.interpolateExpression = (<any>prop.value).source;
+    const ast = (prop.value as e.ASTWithSource).ast;
+    (ast as any).interpolateExpression = (prop.value as any).source;
     this.visitNgTemplateAST(prop.value, this.templateStart + getExpressionDisplacement(prop), prop);
   }
 
@@ -158,8 +157,8 @@ export class BasicTemplateAstVisitor extends SourceMappingVisitor implements ast
   visitBoundText(text: ast.BoundTextAst, context: any): any {
     if (ExpTypes.ASTWithSource(text.value)) {
       // Note that will not be reliable for different interpolation symbols
-      const ast: any = (<e.ASTWithSource>text.value).ast;
-      ast.interpolateExpression = (<any>text.value).source;
+      const ast = (text.value as e.ASTWithSource).ast;
+      (ast as any).interpolateExpression = (text.value as any).source;
       this.visitNgTemplateAST(ast, this.templateStart + getExpressionDisplacement(text));
     }
   }

--- a/src/angular/templates/recursiveAngularExpressionVisitor.ts
+++ b/src/angular/templates/recursiveAngularExpressionVisitor.ts
@@ -13,7 +13,7 @@ export class RecursiveAngularExpressionVisitor extends SourceMappingVisitor impl
   public preDefinedVariables: FlatSymbolTable = {};
 
   constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, protected context: ComponentMetadata, protected basePosition: number) {
-    super(sourceFile, options, context.template.template, basePosition);
+    super(sourceFile, options, context.template!.template, basePosition);
   }
 
   visit(ast: e.AST, context: any) {

--- a/src/angular/templates/templateParser.ts
+++ b/src/angular/templates/templateParser.ts
@@ -50,7 +50,7 @@ let defaultDirectives: DirectiveDeclaration[] = [];
 export const parseTemplate = (template: string, directives: DirectiveDeclaration[] = []) => {
   defaultDirectives = directives.map(d => dummyMetadataFactory(d));
 
-  const TemplateParser = <any>compiler.TemplateParser;
+  const TemplateParser = compiler.TemplateParser as any;
   const expressionParser = new compiler.Parser(new compiler.Lexer());
   const elementSchemaRegistry = new compiler.DomElementSchemaRegistry();
   const ngConsole = new Console();
@@ -131,7 +131,7 @@ export const parseTemplate = (template: string, directives: DirectiveDeclaration
     value: '',
     identifier: null
   };
-  let result: any = null;
+  let result;
   try {
     SemVerDSL.lt('4.1.0', () => {
       result = tmplParser.tryParse(

--- a/src/angular/urlResolvers/abstractResolver.ts
+++ b/src/angular/urlResolvers/abstractResolver.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
-import { isPropertyAssignment } from 'typescript/lib/typescript';
-import { isSimpleTemplateString } from '../../util/utils';
+import { getDecoratorArgument, isSimpleTemplateString } from '../../util/utils';
 
 export interface MetadataUrls {
   templateUrl: string;
@@ -10,55 +9,39 @@ export interface MetadataUrls {
 export abstract class AbstractResolver {
   abstract resolve(decorator: ts.Decorator): MetadataUrls | null;
 
-  protected getTemplateUrl(decorator: ts.Decorator): string | null {
-    const arg = this.getDecoratorArgument(decorator);
+  protected getTemplateUrl(decorator: ts.Decorator): string | undefined {
+    const arg = getDecoratorArgument(decorator);
 
     if (!arg) {
-      return null;
+      return undefined;
     }
 
-    const prop = arg.properties
-      .filter(p => (p.name as any).text === 'templateUrl' && isSimpleTemplateString((p as ts.PropertyAssignment).initializer))
-      .pop();
+    const prop = arg.properties.find(
+      p => (p.name as ts.StringLiteralLike).text === 'templateUrl' && isSimpleTemplateString((p as ts.PropertyAssignment).initializer)
+    );
 
     // We know that it's has an initializer because it's either
     // a template string or a string literal.
-    return prop ? ((prop as ts.PropertyAssignment).initializer as any).text : undefined;
+    return prop ? ((prop as ts.PropertyAssignment).initializer as ts.StringLiteralLike).text : undefined;
   }
 
   protected getStyleUrls(decorator: ts.Decorator): string[] {
-    const arg = this.getDecoratorArgument(decorator);
+    const arg = getDecoratorArgument(decorator);
 
     if (!arg) {
       return [];
     }
 
-    const prop = arg.properties
-      .filter(
-        p => (p.name as any).text === 'styleUrls' && isPropertyAssignment(p) && p.initializer.kind === ts.SyntaxKind.ArrayLiteralExpression
-      )
-      .pop();
+    const prop = arg.properties.find(
+      p => (p.name as any).text === 'styleUrls' && ts.isPropertyAssignment(p) && ts.isArrayLiteralExpression(p.initializer)
+    );
 
     if (prop) {
       return ((prop as ts.PropertyAssignment).initializer as ts.ArrayLiteralExpression).elements
-        .filter(e => isSimpleTemplateString(e))
-        .map(e => (e as any).text);
+        .filter(isSimpleTemplateString)
+        .map(e => (e as ts.StringLiteralLike).text);
     }
 
     return [];
-  }
-
-  protected getDecoratorArgument(decorator: ts.Decorator): ts.ObjectLiteralExpression | null {
-    const expr = <ts.CallExpression>decorator.expression;
-
-    if (expr && expr.arguments && expr.arguments.length) {
-      const arg = expr.arguments[0] as ts.ObjectLiteralExpression;
-
-      if (arg.properties && arg.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-        return arg;
-      }
-    }
-
-    return null;
   }
 }

--- a/src/angularWhitespaceRule.ts
+++ b/src/angularWhitespaceRule.ts
@@ -168,24 +168,24 @@ class WhitespaceTemplateVisitor extends BasicTemplateAstVisitor {
     new SemicolonTemplateVisitor(this.getSourceFile(), this.getOptions(), this.context, this.templateStart)
   ];
 
-  visitBoundText(text: ast.BoundTextAst, context: any): any {
+  visitBoundText(text: ast.BoundTextAst, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitBoundText(text, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );
     super.visitBoundText(text, context);
   }
 
-  visitDirectiveProperty(prop: ast.BoundDirectivePropertyAst, context: any): any {
+  visitDirectiveProperty(prop: ast.BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitDirectiveProperty(prop, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );
@@ -257,10 +257,6 @@ class PipeWhitespaceVisitor extends RecursiveAngularExpressionVisitor implements
   getCheckOption(): CheckOption {
     return 'check-pipe';
   }
-
-  protected isAsyncBinding(expr: any) {
-    return expr instanceof ast.BindingPipe && expr.name === 'async';
-  }
 }
 
 class TemplateExpressionVisitor extends RecursiveAngularExpressionVisitor {
@@ -268,13 +264,13 @@ class TemplateExpressionVisitor extends RecursiveAngularExpressionVisitor {
     new PipeWhitespaceVisitor(this.getSourceFile(), this.getOptions(), this.context, this.basePosition)
   ];
 
-  visitPipe(expr: ast.BindingPipe, context: any): any {
+  visitPipe(expr: ast.BindingPipe, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .map(v => v.addParentAST(this.parentAST))
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitPipe(expr, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );

--- a/src/bananaInBoxRule.ts
+++ b/src/bananaInBoxRule.ts
@@ -27,7 +27,7 @@ const getReplacements = (text: ast.BoundEventAst, absolutePosition: number) => {
 };
 
 class BananaInBoxTemplateVisitor extends BasicTemplateAstVisitor {
-  visitEvent(prop: ast.BoundEventAst, context: any): any {
+  visitEvent(prop: ast.BoundEventAst, context: BasicTemplateAstVisitor): any {
     if (prop.name) {
       let error: string | null = null;
 

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -2,7 +2,7 @@ import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { NgWalker } from './angular/ngWalker';
-import { getInterfaceName } from './util/utils';
+import { getSymbolName } from './util/utils';
 
 import { DirectiveMetadata } from './angular/metadata';
 
@@ -52,8 +52,8 @@ export class ClassMetadataWalker extends NgWalker {
       if (
         i.length !== 0 &&
         i[0].types
-          .map(getInterfaceName)
-          .filter(x => !!x)
+          .map(getSymbolName)
+          .filter(Boolean)
           .some(x => x.endsWith(ValidatorSuffix))
       ) {
         suffixes.push(ValidatorSuffix);

--- a/src/i18nRule.ts
+++ b/src/i18nRule.ts
@@ -108,40 +108,40 @@ class I18NTemplateVisitor extends BasicTemplateAstVisitor {
     new I18NTextVisitor(this.getSourceFile(), this.getOptions(), this.context, this.templateStart)
   ];
 
-  visit(a: any, context: any) {
-    super.visit!(a, context);
+  visit(node: ast.TemplateAst, context: BasicTemplateAstVisitor) {
+    super.visit!(node, context);
   }
 
-  visitAttr(attr: ast.AttrAst, context: any): any {
+  visitAttr(attr: ast.AttrAst, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitAttr(attr, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );
     super.visitAttr(attr, context);
   }
 
-  visitElement(element: ast.ElementAst, context: any): any {
+  visitElement(element: ast.ElementAst, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitElement(element, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );
     super.visitElement(element, context);
   }
 
-  visitText(text: ast.TextAst, context: any): any {
+  visitText(text: ast.TextAst, context: BasicTemplateAstVisitor): any {
     const options = this.getOptions();
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitText(text, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );
@@ -153,7 +153,7 @@ class I18NTemplateVisitor extends BasicTemplateAstVisitor {
     this.visitors
       .filter(v => options.indexOf(v.getCheckOption()) >= 0)
       .map(v => v.visitBoundText(text, this))
-      .filter(f => !!f)
+      .filter(Boolean)
       .forEach(f =>
         this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
       );

--- a/src/maxInlineDeclarationsRule.ts
+++ b/src/maxInlineDeclarationsRule.ts
@@ -114,7 +114,9 @@ export class MaxInlineDeclarationsWalker extends NgWalker {
 
   private getInlineAnimationsLinesCount(metadata: ComponentMetadata): number {
     return (metadata.animations || []).reduce((previousValue, currentValue) => {
-      previousValue += this.getLinesCount(currentValue.animation.source);
+      if (currentValue && currentValue.animation) {
+        previousValue += this.getLinesCount(currentValue.animation.source);
+      }
 
       return previousValue;
     }, 0);
@@ -129,14 +131,14 @@ export class MaxInlineDeclarationsWalker extends NgWalker {
 
     const failureMessage = getAnimationsFailure(linesCount, this.animationsLinesLimit);
 
-    for (const animation of metadata.animations) {
-      this.addFailureAtNode(animation.node!, failureMessage);
+    for (const animation of metadata.animations!) {
+      this.addFailureAtNode(animation!.node!, failureMessage);
     }
   }
 
   private getInlineStylesLinesCount(metadata: ComponentMetadata): number {
     return (metadata.styles || []).reduce((previousValue, currentValue) => {
-      if (!currentValue.url) {
+      if (currentValue && !currentValue.url) {
         previousValue += this.getLinesCount(currentValue.style.source);
       }
 
@@ -153,13 +155,13 @@ export class MaxInlineDeclarationsWalker extends NgWalker {
 
     const failureMessage = getStylesFailure(linesCount, this.stylesLinesLimit);
 
-    for (const style of metadata.styles) {
-      this.addFailureAtNode(style.node!, failureMessage);
+    for (const style of metadata.styles!) {
+      this.addFailureAtNode(style!.node!, failureMessage);
     }
   }
 
   private getTemplateLinesCount(metadata: ComponentMetadata): number {
-    return this.hasInlineTemplate(metadata) ? this.getLinesCount(metadata.template.template.source) : 0;
+    return this.hasInlineTemplate(metadata) ? this.getLinesCount(metadata.template!.template.source) : 0;
   }
 
   private hasInlineTemplate(metadata: ComponentMetadata): boolean {
@@ -175,6 +177,6 @@ export class MaxInlineDeclarationsWalker extends NgWalker {
 
     const failureMessage = getTemplateFailure(linesCount, this.templateLinesLimit);
 
-    this.addFailureAtNode(metadata.template.node!, failureMessage);
+    this.addFailureAtNode(metadata.template!.node!, failureMessage);
   }
 }

--- a/src/noAttributeParameterDecoratorRule.ts
+++ b/src/noAttributeParameterDecoratorRule.ts
@@ -26,10 +26,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     validate(ts.SyntaxKind.Constructor)(node => {
       return Maybe.lift(node.parent)
         .fmap(parent => {
-          if (parent!.kind === ts.SyntaxKind.ClassExpression && (parent!.parent as any).name) {
-            return (parent!.parent as any).name.text;
-          } else if (parent!.kind === ts.SyntaxKind.ClassDeclaration) {
-            return (parent as any).name!.text;
+          if (parent && ts.isClassExpression(parent) && (parent.parent as any).name) {
+            return (parent.parent as any).name.text;
+          } else if (parent && ts.isClassDeclaration(parent)) {
+            return parent.name!.text;
           }
         })
         .bind(parentName => {
@@ -38,7 +38,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
             return Maybe.lift(p.decorators).bind(decorators => {
               // Check if any @Attribute
-              const decoratorsFailed = listToMaybe(decorators!.map(d => Rule.decoratorIsAttribute(d)));
+              const decoratorsFailed = listToMaybe(decorators.map(d => Rule.decoratorIsAttribute(d)));
 
               // We only care about 1 since we highlight the whole 'parameter'
               return (decoratorsFailed as any).fmap(() => new Failure(p, sprintf(Rule.FAILURE_STRING, parentName, text, text)));

--- a/src/noInputRenameRule.ts
+++ b/src/noInputRenameRule.ts
@@ -3,6 +3,7 @@ import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { DirectiveMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
+import { getClassName } from './util/utils';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -47,13 +48,13 @@ export class InputMetadataWalker extends NgWalker {
   }
 
   private validateInput(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {
-    const className = (property.parent as ts.PropertyAccessExpression).name.getText();
-    const propertyName = property.name.getText();
+    const className = getClassName(property)!;
+    const memberName = property.name.getText();
 
-    if (args.length === 0 || this.canPropertyBeAliased(args[0], propertyName)) {
+    if (args.length === 0 || this.canPropertyBeAliased(args[0], memberName)) {
       return;
     }
 
-    this.addFailureAtNode(property, getFailureMessage(className, propertyName));
+    this.addFailureAtNode(property, getFailureMessage(className, memberName));
   }
 }

--- a/src/propertyDecoratorBase.ts
+++ b/src/propertyDecoratorBase.ts
@@ -1,7 +1,7 @@
+import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { sprintf } from 'sprintf-js';
-import { IOptions } from 'tslint';
+import { getDecoratorArgument, getDecoratorName } from './util/utils';
 
 export interface IUsePropertyDecoratorConfig {
   propertyName: string;
@@ -10,17 +10,20 @@ export interface IUsePropertyDecoratorConfig {
 }
 
 export class UsePropertyDecorator extends Lint.Rules.AbstractRule {
-  public static formatFailureString(config: IUsePropertyDecoratorConfig, decoratorName: string, className: string) {
-    let decorators = config.decoratorName;
-    if (decorators instanceof Array) {
-      decorators = (<string[]>decorators).map(d => `"@${d}"`).join(', ');
+  public static formatFailureString(config: IUsePropertyDecoratorConfig, decoratorStr: string, className: string) {
+    const { decoratorName, errorMessage, propertyName } = config;
+    let decorators: string | string[];
+
+    if (decoratorName instanceof Array) {
+      decorators = decoratorName.map(d => `"@${d}"`).join(', ');
     } else {
-      decorators = `"@${decorators}"`;
+      decorators = `"@${decoratorName}"`;
     }
-    return sprintf(config.errorMessage, decoratorName, className, config.propertyName, decorators);
+
+    return sprintf(errorMessage, decoratorStr, className, propertyName, decorators);
   }
 
-  constructor(private config: IUsePropertyDecoratorConfig, options: IOptions) {
+  constructor(private config: IUsePropertyDecoratorConfig, options: Lint.IOptions) {
     super(options);
   }
 
@@ -35,26 +38,26 @@ class DirectiveMetadataWalker extends Lint.RuleWalker {
   }
 
   visitClassDeclaration(node: ts.ClassDeclaration) {
-    (<ts.NodeArray<ts.Decorator>>node.decorators).forEach(this.validateDecorator.bind(this, node.name!.text));
+    ts.createNodeArray(node.decorators).forEach(this.validateDecorator.bind(this, node.name!.text));
     super.visitClassDeclaration(node);
   }
 
   private validateDecorator(className: string, decorator: ts.Decorator) {
-    let baseExpr = <any>decorator.expression || {};
-    let expr = baseExpr.expression || {};
-    let name = expr.text;
-    let args = baseExpr.arguments || [];
-    let arg = args[0];
-    if (/^(Component|Directive)$/.test(name) && arg) {
-      this.validateProperty(className, name, arg);
+    const argument = getDecoratorArgument(decorator)!;
+    const name = getDecoratorName(decorator);
+
+    if (name && argument && /^(Component|Directive)$/.test(name)) {
+      this.validateProperty(className, name, argument);
     }
   }
 
   private validateProperty(className: string, decoratorName: string, arg: ts.ObjectLiteralExpression) {
-    if (arg.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-      arg.properties.filter(prop => prop.name!.getText() === this.config.propertyName).forEach(prop => {
-        this.addFailureAtNode(prop, UsePropertyDecorator.formatFailureString(this.config, decoratorName, className));
-      });
+    if (!ts.isObjectLiteralExpression(arg)) {
+      return;
     }
+
+    arg.properties.filter(prop => prop.name!.getText() === this.config.propertyName).forEach(prop => {
+      this.addFailureAtNode(prop, UsePropertyDecorator.formatFailureString(this.config, decoratorName, className));
+    });
   }
 }

--- a/src/templatesNoNegatedAsyncRule.ts
+++ b/src/templatesNoNegatedAsyncRule.ts
@@ -53,7 +53,7 @@ class TemplateToNgTemplateVisitor extends RecursiveAngularExpressionVisitor {
     ]);
   }
 
-  protected isAsyncBinding(expr: any) {
+  protected isAsyncBinding(expr: ast.AST) {
     return expr instanceof ast.BindingPipe && expr.name === 'async';
   }
 }

--- a/src/trackByFunctionRule.ts
+++ b/src/trackByFunctionRule.ts
@@ -27,12 +27,12 @@ export const getFailureMessage = (): string => {
 };
 
 class TrackByFunctionTemplateVisitor extends BasicTemplateAstVisitor {
-  visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: any): any {
+  visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
     this.validateDirective(prop, context);
     super.visitDirectiveProperty(prop, context);
   }
 
-  private validateDirective(prop: BoundDirectivePropertyAst, context: any): any {
+  private validateDirective(prop: BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
     const { templateName } = prop;
 
     if (templateName !== 'ngForOf') {
@@ -41,7 +41,7 @@ class TrackByFunctionTemplateVisitor extends BasicTemplateAstVisitor {
 
     const pattern = /trackBy\s*:|\[ngForTrackBy\]\s*=\s*['"].*['"]/;
 
-    if (pattern.test(context.codeWithMap.source)) {
+    if (pattern.test(context.codeWithMap.source!)) {
       return;
     }
 
@@ -60,7 +60,7 @@ class TrackByTemplateVisitor extends BasicTemplateAstVisitor {
     new TrackByFunctionTemplateVisitor(this.getSourceFile(), this.getOptions(), this.context, this.templateStart)
   ]);
 
-  visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: any): any {
+  visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
     this.visitors.forEach(visitor => visitor.visitDirectiveProperty(prop, this));
 
     super.visitDirectiveProperty(prop, context);

--- a/src/useLifeCycleInterfaceRule.ts
+++ b/src/useLifeCycleInterfaceRule.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
-import { getInterfaceName } from './util/utils';
+import { getSymbolName } from './util/utils';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -37,7 +37,7 @@ export class ClassMetadataWalker extends Lint.RuleWalker {
   visitClassDeclaration(node: ts.ClassDeclaration) {
     const className = node.name!.text;
     const interfaces = this.extractInterfaces(node);
-    const methods = node.members.filter(m => m.kind === ts.SyntaxKind.MethodDeclaration);
+    const methods = node.members.filter(ts.isMethodDeclaration);
 
     this.validateMethods(methods, interfaces, className);
     super.visitClassDeclaration(node);
@@ -48,7 +48,7 @@ export class ClassMetadataWalker extends Lint.RuleWalker {
     if (node.heritageClauses) {
       const interfacesClause = node.heritageClauses.filter(h => h.token === ts.SyntaxKind.ImplementsKeyword);
       if (interfacesClause.length !== 0) {
-        interfaces = interfacesClause[0].types.map(getInterfaceName);
+        interfaces = interfacesClause[0].types.map(getSymbolName);
       }
     }
     return interfaces;

--- a/src/usePipeDecoratorRule.ts
+++ b/src/usePipeDecoratorRule.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules, RuleWalker } from 'tslint/lib';
 import { ClassDeclaration, SourceFile, SyntaxKind } from 'typescript/lib/typescript';
-import { getDecoratorName, getInterfaceName } from './util/utils';
+import { getDecoratorName, getSymbolName } from './util/utils';
 
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -35,7 +35,7 @@ const hasPipeTransform = (node: ClassDeclaration): boolean => {
 
   const interfacesClauses = heritageClauses.filter(h => h.token === SyntaxKind.ImplementsKeyword);
 
-  return interfacesClauses.length > 0 && interfacesClauses[0].types.map(getInterfaceName).indexOf(Rule.PIPE_INTERFACE_NAME) !== -1;
+  return interfacesClauses.length > 0 && interfacesClauses[0].types.map(getSymbolName).indexOf(Rule.PIPE_INTERFACE_NAME) !== -1;
 };
 
 export class ClassMetadataWalker extends RuleWalker {

--- a/src/usePipeTransformInterfaceRule.ts
+++ b/src/usePipeTransformInterfaceRule.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules, RuleWalker } from 'tslint/lib';
 import { ClassDeclaration, SourceFile, SyntaxKind } from 'typescript/lib/typescript';
-import { getDecoratorName, getInterfaceName } from './util/utils';
+import { getDecoratorName, getSymbolName } from './util/utils';
 
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -35,7 +35,7 @@ const hasPipeTransform = (node: ClassDeclaration): boolean => {
 
   const interfacesClauses = heritageClauses.filter(h => h.token === SyntaxKind.ImplementsKeyword);
 
-  return interfacesClauses.length > 0 && interfacesClauses[0].types.map(getInterfaceName).indexOf(Rule.PIPE_INTERFACE_NAME) !== -1;
+  return interfacesClauses.length > 0 && interfacesClauses[0].types.map(getSymbolName).indexOf(Rule.PIPE_INTERFACE_NAME) !== -1;
 };
 
 export class ClassMetadataWalker extends RuleWalker {

--- a/src/useViewEncapsulationRule.ts
+++ b/src/useViewEncapsulationRule.ts
@@ -1,5 +1,5 @@
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
-import { SourceFile } from 'typescript/lib/typescript';
+import { isPropertyAccessExpression, SourceFile } from 'typescript/lib/typescript';
 import { ComponentMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
 import { getDecoratorPropertyInitializer } from './util/utils';
@@ -31,7 +31,7 @@ class ViewEncapsulationWalker extends NgWalker {
   private validateComponent(metadata: ComponentMetadata): void {
     const encapsulation = getDecoratorPropertyInitializer(metadata.decorator, 'encapsulation');
 
-    if (!encapsulation || encapsulation.name.text !== 'None') {
+    if (!encapsulation || (isPropertyAccessExpression(encapsulation) && encapsulation.name.text !== 'None')) {
       return;
     }
 

--- a/src/util/astQuery.ts
+++ b/src/util/astQuery.ts
@@ -1,16 +1,9 @@
 import * as ts from 'typescript';
 import { Maybe, ifTrue } from './function';
+import { isSimpleTemplateString } from './utils';
 
 export function callExpression(dec?: ts.Decorator): Maybe<ts.CallExpression | undefined> {
-  return Maybe.lift(dec!.expression).fmap(expr => (ts.isCallExpression(expr!) ? (expr as ts.CallExpression) : undefined));
-}
-
-export function isPropertyAssignment(expr: ts.ObjectLiteralElement): expr is ts.PropertyAssignment {
-  return expr && expr.kind === ts.SyntaxKind.PropertyAssignment;
-}
-
-export function isSimpleTemplateString(expr: ts.Expression): expr is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
-  return (expr && expr.kind === ts.SyntaxKind.StringLiteral) || expr.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
+  return Maybe.lift(dec!.expression).fmap(expr => (expr && ts.isCallExpression(expr) ? expr : undefined));
 }
 
 export function hasProperties(expr?: ts.ObjectLiteralExpression): boolean {
@@ -18,35 +11,31 @@ export function hasProperties(expr?: ts.ObjectLiteralExpression): boolean {
 }
 
 export function objectLiteralExpression(expr?: ts.CallExpression): Maybe<ts.ObjectLiteralExpression | undefined> {
-  return Maybe.lift(expr!.arguments[0]).fmap(
-    arg0 => (ts.isObjectLiteralExpression(arg0!) ? (arg0 as ts.ObjectLiteralExpression) : undefined)
-  );
+  return Maybe.lift(expr!.arguments[0]).fmap(arg0 => (arg0 && ts.isObjectLiteralExpression(arg0) ? arg0 : undefined));
 }
 
 export function withIdentifier(identifier: string): (expr: ts.CallExpression) => Maybe<ts.CallExpression | undefined> {
   return ifTrue(expr => ts.isIdentifier(expr.expression) && expr.expression.text === identifier);
 }
 
-export type WithStringInitializer = ts.StringLiteral | ts.NoSubstitutionTemplateLiteral;
-
 export function isProperty(propName: string, p: ts.ObjectLiteralElement): boolean {
-  return isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === propName;
+  return ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === propName;
 }
 
 export function getInitializer(p: ts.ObjectLiteralElement): Maybe<ts.Expression | undefined> {
-  return Maybe.lift(isPropertyAssignment(p) && ts.isIdentifier(p.name) ? p.initializer : undefined);
+  return Maybe.lift(p && ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) ? p.initializer : undefined);
 }
 
 export function getStringInitializerFromProperty(
   propertyName: string,
   ps: ts.NodeArray<ts.ObjectLiteralElement>
-): Maybe<WithStringInitializer | undefined> {
+): Maybe<ts.StringLiteralLike | undefined> {
   const property = ps.find(p => isProperty(propertyName, p))!;
 
   return (
     getInitializer(property)
-      // A little wrinkle to return Maybe<WithStringInitializer>
-      .fmap(expr => (isSimpleTemplateString(expr!) ? (expr as WithStringInitializer) : undefined))
+      // A little wrinkle to return Maybe<ts.StringLiteralLike>
+      .fmap(expr => (expr && isSimpleTemplateString(expr) ? (expr as ts.StringLiteralLike) : undefined))
   );
 }
 

--- a/src/util/classDeclarationUtils.ts
+++ b/src/util/classDeclarationUtils.ts
@@ -2,36 +2,30 @@ import * as ts from 'typescript';
 import { FlatSymbolTable } from '../angular/templates/recursiveAngularExpressionVisitor';
 
 export const getDeclaredProperties = (declaration: ts.ClassDeclaration) => {
-  const m = declaration.members;
-  const ctr = m.filter((m: any) => m.kind === ts.SyntaxKind.Constructor).pop();
-  let params: any = [];
-  if (ctr) {
-    params = (((<ts.ConstructorDeclaration>ctr).parameters || []) as any).filter((p: any) => p.kind === ts.SyntaxKind.Parameter);
-  }
-  return m
-    .filter(
-      (m: any) =>
-        m.kind === ts.SyntaxKind.PropertyDeclaration || m.kind === ts.SyntaxKind.GetAccessor || m.kind === ts.SyntaxKind.SetAccessor
-    )
-    .concat(params);
+  const { members } = declaration;
+  const ctr = members.find(ts.isConstructorDeclaration);
+  const params = (ctr ? ctr.parameters.filter(ts.isParameter) : []) as any;
+
+  return members.filter(x => ts.isPropertyDeclaration(x) || ts.isGetAccessor(x) || ts.isSetAccessor(x)).concat(params);
 };
 
 export const getDeclaredPropertyNames = (declaration: ts.ClassDeclaration) => {
   return getDeclaredProperties(declaration)
-    .filter((p: any) => p && p.name)
-    .reduce((accum: FlatSymbolTable, p: any) => {
-      accum[p.name.text] = true;
+    .filter(p => p.name && ts.isIdentifier(p.name))
+    .map(p => (p.name as ts.Identifier).text)
+    .reduce<FlatSymbolTable>((accum, p) => {
+      accum[p] = true;
       return accum;
     }, {});
 };
 
 export const getDeclaredMethods = (declaration: ts.ClassDeclaration) => {
-  return declaration.members.filter(m => m.kind === ts.SyntaxKind.MethodDeclaration);
+  return declaration.members.filter(ts.isMethodDeclaration);
 };
 
 export const getDeclaredMethodNames = (declaration: ts.ClassDeclaration) => {
   return getDeclaredMethods(declaration)
-    .map(d => (<ts.Identifier>d.name).text)
+    .map(d => (d.name as ts.Identifier).text)
     .reduce<FlatSymbolTable>((accum, m) => {
       accum[m] = true;
       return accum;

--- a/src/util/ngQuery.ts
+++ b/src/util/ngQuery.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { decoratorArgument, getInitializer, getStringInitializerFromProperty, isProperty, WithStringInitializer } from './astQuery';
+import { decoratorArgument, getInitializer, getStringInitializerFromProperty, isProperty } from './astQuery';
 import { Maybe } from './function';
 
 export function getAnimations(dec: ts.Decorator): Maybe<ts.ArrayLiteralExpression | undefined> {
@@ -14,14 +14,14 @@ export function getInlineStyle(dec: ts.Decorator): Maybe<ts.ArrayLiteralExpressi
   return decoratorArgument(dec).bind(expr => {
     const property = expr!.properties.find(p => isProperty('styles', p))!;
 
-    return getInitializer(property).fmap(expr => (ts.isArrayLiteralExpression(expr!) ? (expr as ts.ArrayLiteralExpression) : undefined));
+    return getInitializer(property).fmap(expr => (expr && ts.isArrayLiteralExpression(expr) ? expr : undefined));
   });
 }
 
-export function getTemplate(dec: ts.Decorator): Maybe<WithStringInitializer | undefined> {
+export function getTemplate(dec: ts.Decorator): Maybe<ts.StringLiteralLike | undefined> {
   return decoratorArgument(dec).bind(expr => getStringInitializerFromProperty('template', expr!.properties));
 }
 
-export function getTemplateUrl(dec: ts.Decorator): Maybe<WithStringInitializer | undefined> {
+export function getTemplateUrl(dec: ts.Decorator): Maybe<ts.StringLiteralLike | undefined> {
   return decoratorArgument(dec).bind(expr => getStringInitializerFromProperty('templateUrl', expr!.properties));
 }

--- a/src/walkerFactory/walkerFactory.ts
+++ b/src/walkerFactory/walkerFactory.ts
@@ -32,9 +32,7 @@ class NgComponentWalkerBuilder implements WalkerBuilder<'NgComponent'> {
     const self = this;
     const e = class extends NgWalker {
       visitNgComponent(meta: ComponentMetadata) {
-        self._where(meta).fmap(failure => {
-          this.addFailureAtNode(failure!.node, failure!.message);
-        });
+        self._where(meta).fmap(failure => this.addFailureAtNode(failure.node, failure.message));
         super.visitNgComponent(meta);
       }
     };

--- a/src/walkerFactory/walkerFn.ts
+++ b/src/walkerFactory/walkerFn.ts
@@ -22,7 +22,7 @@ export interface ComponentValidator {
 export function validate(syntaxKind: ts.SyntaxKind): F1<ValidateFn<ts.Node>, NodeValidator> {
   return validateFn => ({
     kind: 'Node',
-    validate: (node: ts.Node, options: WalkerOptions) => (node.kind === syntaxKind ? validateFn!(node, options) : Maybe.nothing)
+    validate: (node: ts.Node, options: WalkerOptions) => (node.kind === syntaxKind ? validateFn(node, options) : Maybe.nothing)
   });
 }
 

--- a/test/angular/basicCssAstVisitor.spec.ts
+++ b/test/angular/basicCssAstVisitor.spec.ts
@@ -8,7 +8,7 @@ import * as spies from 'chai-spies';
 
 chai.use(spies);
 
-const chaiSpy = (<any>chai).spy;
+const chaiSpy = (chai as any).spy;
 
 describe('basicCssAstVisitor', () => {
   it('should use the default css walker by default', () => {
@@ -28,11 +28,11 @@ describe('basicCssAstVisitor', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(BasicCssAstVisitor.prototype, 'visitCssStyleSheet');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.have.been).called();
+        (chai.expect(templateSpy).to.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -57,13 +57,13 @@ describe('basicCssAstVisitor', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let selectorSpy = chaiSpy.on(BasicCssAstVisitor.prototype, 'visitCssSelector');
         let pseudoSelectorSpy = chaiSpy.on(BasicCssAstVisitor.prototype, 'visitCssPseudoSelector');
         walker.walk(sf);
-        (<any>chai.expect(selectorSpy).to.have.been).called();
-        (<any>chai.expect(pseudoSelectorSpy).to.have.been).called();
+        (chai.expect(selectorSpy).to.have.been as any).called();
+        (chai.expect(pseudoSelectorSpy).to.have.been as any).called();
       })
       .not.to.throw();
   });

--- a/test/angular/metadataReader.spec.ts
+++ b/test/angular/metadataReader.spec.ts
@@ -1,11 +1,11 @@
+import { expect } from 'chai';
 import * as ts from 'typescript';
-import chai = require('chai');
 
+import { Config } from '../../src/angular/config';
 import { DummyFileResolver } from '../../src/angular/fileResolver/dummyFileResolver';
 import { FsFileResolver } from '../../src/angular/fileResolver/fsFileResolver';
-import { MetadataReader } from '../../src/angular/metadataReader';
 import { ComponentMetadata } from '../../src/angular/metadata';
-import { Config } from '../../src/angular/config';
+import { MetadataReader } from '../../src/angular/metadataReader';
 
 import { join, normalize } from 'path';
 
@@ -24,8 +24,8 @@ describe('metadataReader', () => {
       `;
       const reader = new MetadataReader(new DummyFileResolver());
       const ast = getAst(code);
-      const metadata = reader.read(<ts.ClassDeclaration>last(ast.statements))!;
-      chai.expect(metadata.selector).eq('foo');
+      const metadata = reader.read(last(ast.statements) as ts.ClassDeclaration)!;
+      expect(metadata.selector).eq('foo');
     });
 
     it('should not fail with empty decorator', () => {
@@ -35,8 +35,8 @@ describe('metadataReader', () => {
       `;
       const reader = new MetadataReader(new DummyFileResolver());
       const ast = getAst(code);
-      const metadata = reader.read(<ts.ClassDeclaration>last(ast.statements))!;
-      chai.expect(metadata.selector).eq(undefined);
+      const metadata = reader.read(last(ast.statements) as ts.ClassDeclaration)!;
+      expect(metadata.selector).eq(undefined);
     });
 
     it('should provide class declaration', () => {
@@ -48,7 +48,7 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata.controller).eq(classDeclaration);
+      expect(metadata.controller).eq(classDeclaration);
     });
   });
 
@@ -66,13 +66,13 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code).eq('bar');
-      chai.expect(m.template.url).eq(undefined);
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code).eq('bar');
+      expect(m.template!.url).eq(undefined);
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work with external template', () => {
@@ -88,13 +88,13 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code).eq('');
-      chai.expect(m.template.url).eq('bar');
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code).eq('');
+      expect(m.template!.url).eq('bar');
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work with ignore templateUrl when has template', () => {
@@ -111,13 +111,13 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code).eq('qux');
-      chai.expect(m.template.url).eq(undefined);
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code).eq('qux');
+      expect(m.template!.url).eq(undefined);
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work with relative paths', () => {
@@ -133,13 +133,13 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code.trim()).eq('<div></div>');
-      chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code.trim()).eq('<div></div>');
+      expect(m.template!.url!.endsWith('foo.html')).eq(true);
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work with absolute paths', () => {
@@ -155,13 +155,13 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code.trim()).eq('<div></div>');
-      chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code.trim()).eq('<div></div>');
+      expect(m.template!.url!.endsWith('foo.html')).eq(true);
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work invoke Config.resolveUrl after all resolves', () => {
@@ -170,7 +170,7 @@ describe('metadataReader', () => {
       try {
         Config.resolveUrl = url => {
           invoked = true;
-          chai.expect(url!.startsWith(normalize(join(__dirname, '../..')))).eq(true);
+          expect(url!.startsWith(normalize(join(__dirname, '../..')))).eq(true);
           return url;
         };
         const code = `
@@ -185,16 +185,16 @@ describe('metadataReader', () => {
         const reader = new MetadataReader(new FsFileResolver());
         const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
-        chai.expect(invoked).eq(false);
+        expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        chai.expect(metadata instanceof ComponentMetadata).eq(true);
-        chai.expect(metadata.selector).eq('foo');
+        expect(metadata instanceof ComponentMetadata).eq(true);
+        expect(metadata.selector).eq('foo');
         const m = <ComponentMetadata>metadata;
-        chai.expect(m.template.template.code.trim()).eq('<div></div>');
-        chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-        chai.expect(m.styles[0].style.code).eq('baz');
-        chai.expect(m.styles[0].url).eq(undefined);
-        chai.expect(invoked).eq(true);
+        expect(m.template!.template.code.trim()).eq('<div></div>');
+        expect(m.template!.url!.endsWith('foo.html')).eq(true);
+        expect(m.styles![0]!.style.code).eq('baz');
+        expect(m.styles![0]!.url).eq(undefined);
+        expect(invoked).eq(true);
       } finally {
         Config.resolveUrl = bak;
       }
@@ -206,7 +206,7 @@ describe('metadataReader', () => {
       try {
         Config.transformTemplate = code => {
           invoked = true;
-          chai.expect(code.trim()).eq('<div></div>');
+          expect(code.trim()).eq('<div></div>');
           return { code };
         };
         const code = `
@@ -221,16 +221,16 @@ describe('metadataReader', () => {
         const reader = new MetadataReader(new FsFileResolver());
         const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
-        chai.expect(invoked).eq(false);
+        expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        chai.expect(metadata instanceof ComponentMetadata).eq(true);
-        chai.expect(metadata.selector).eq('foo');
+        expect(metadata instanceof ComponentMetadata).eq(true);
+        expect(metadata.selector).eq('foo');
         const m = <ComponentMetadata>metadata;
-        chai.expect(m.template.template.code.trim()).eq('<div></div>');
-        chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-        chai.expect(m.styles[0].style.code).eq('baz');
-        chai.expect(m.styles[0].url).eq(undefined);
-        chai.expect(invoked).eq(true);
+        expect(m.template!.template.code.trim()).eq('<div></div>');
+        expect(m.template!.url!.endsWith('foo.html')).eq(true);
+        expect(m.styles![0]!.style.code).eq('baz');
+        expect(m.styles![0]!.url).eq(undefined);
+        expect(invoked).eq(true);
       } finally {
         Config.transformTemplate = bak;
       }
@@ -242,7 +242,7 @@ describe('metadataReader', () => {
       try {
         Config.transformStyle = code => {
           invoked = true;
-          chai.expect(code).eq('baz');
+          expect(code).eq('baz');
           return { code };
         };
         const code = `
@@ -257,16 +257,16 @@ describe('metadataReader', () => {
         const reader = new MetadataReader(new FsFileResolver());
         const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
-        chai.expect(invoked).eq(false);
+        expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        chai.expect(metadata instanceof ComponentMetadata).eq(true);
-        chai.expect(metadata.selector).eq('foo');
+        expect(metadata instanceof ComponentMetadata).eq(true);
+        expect(metadata.selector).eq('foo');
         const m = <ComponentMetadata>metadata;
-        chai.expect(m.template.template.code.trim()).eq('<div></div>');
-        chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-        chai.expect(m.styles[0].style.code).eq('baz');
-        chai.expect(m.styles[0].url).eq(undefined);
-        chai.expect(invoked).eq(true);
+        expect(m.template!.template.code.trim()).eq('<div></div>');
+        expect(m.template!.url!.endsWith('foo.html')).eq(true);
+        expect(m.styles![0]!.style.code).eq('baz');
+        expect(m.styles![0]!.url).eq(undefined);
+        expect(invoked).eq(true);
       } finally {
         Config.transformStyle = bak;
       }
@@ -286,13 +286,13 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/specialsymbols/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code.trim()).eq('<div>`</div>');
-      chai.expect(m.template.url!.endsWith('foo.html')).eq(true);
-      chai.expect(m.styles[0].style.code).eq('baz');
-      chai.expect(m.styles[0].url).eq(undefined);
+      expect(m.template!.template.code.trim()).eq('<div>`</div>');
+      expect(m.template!.url!.endsWith('foo.html')).eq(true);
+      expect(m.styles![0]!.style.code).eq('baz');
+      expect(m.styles![0]!.url).eq(undefined);
     });
 
     it('should work work with templates with "`"', () => {
@@ -309,13 +309,13 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/notsupported/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      chai.expect(metadata instanceof ComponentMetadata).eq(true);
-      chai.expect(metadata.selector).eq('foo');
+      expect(metadata instanceof ComponentMetadata).eq(true);
+      expect(metadata.selector).eq('foo');
       const m = <ComponentMetadata>metadata;
-      chai.expect(m.template.template.code.trim()).eq('');
-      chai.expect(m.template.url!.endsWith('foo.dust')).eq(true);
-      chai.expect(m.styles[0].style.code).eq('');
-      chai.expect(m.styles[0].url!.endsWith('foo.sty')).eq(true);
+      expect(m.template!.template.code.trim()).eq('');
+      expect(m.template!.url!.endsWith('foo.dust')).eq(true);
+      expect(m.styles![0]!.style.code).eq('');
+      expect(m.styles![0]!.url!.endsWith('foo.sty')).eq(true);
     });
   });
 });

--- a/test/angular/ngWalker.spec.ts
+++ b/test/angular/ngWalker.spec.ts
@@ -10,7 +10,8 @@ import * as spies from 'chai-spies';
 
 chai.use(spies);
 
-const chaiSpy = (<any>chai).spy;
+const chaiSpy = (chai as any).spy;
+
 describe('ngWalker', () => {
   it('should visit components, directives, pipes, injectables, and modules', () => {
     let source = `
@@ -46,11 +47,11 @@ describe('ngWalker', () => {
     let modSpy = chaiSpy.on(walker, 'visitNgModule');
     let injSpy = chaiSpy.on(walker, 'visitNgInjectable');
     walker.walk(sf);
-    (<any>chai.expect(cmpSpy).to.have.been).called();
-    (<any>chai.expect(dirSpy).to.have.been).called();
-    (<any>chai.expect(pipeSpy).to.have.been).called();
-    (<any>chai.expect(modSpy).to.have.been).called();
-    (<any>chai.expect(injSpy).to.have.been).called();
+    (chai.expect(cmpSpy).to.have.been as any).called();
+    (chai.expect(dirSpy).to.have.been as any).called();
+    (chai.expect(pipeSpy).to.have.been as any).called();
+    (chai.expect(modSpy).to.have.been as any).called();
+    (chai.expect(injSpy).to.have.been as any).called();
   });
 
   it('should visit inputs and outputs with args', () => {
@@ -100,7 +101,7 @@ describe('ngWalker', () => {
     });
     let templateSpy = chaiSpy.on(BasicTemplateAstVisitor.prototype, 'visitElement');
     walker.walk(sf);
-    (<any>chai.expect(templateSpy).to.have.been).called();
+    (chai.expect(templateSpy).to.have.been as any).called();
   });
 
   it('should visit component template expressions', () => {
@@ -121,7 +122,7 @@ describe('ngWalker', () => {
     let walker = new NgWalker(sf, ruleArgs);
     let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
     walker.walk(sf);
-    (<any>chai.expect(templateSpy).to.have.been).called();
+    (chai.expect(templateSpy).to.have.been as any).called();
   });
 
   it('should not thow when a template is not literal', () => {
@@ -141,11 +142,11 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.not.have.been).called();
+        (chai.expect(templateSpy).to.not.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -167,11 +168,11 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.not.have.been).called();
+        (chai.expect(templateSpy).to.not.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -193,11 +194,11 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.not.have.been).called();
+        (chai.expect(templateSpy).to.not.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -218,11 +219,11 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.not.have.been).called();
+        (chai.expect(templateSpy).to.not.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -240,11 +241,11 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         let templateSpy = chaiSpy.on(RecursiveAngularExpressionVisitor.prototype, 'visitPropertyRead');
         walker.walk(sf);
-        (<any>chai.expect(templateSpy).to.not.have.been).called();
+        (chai.expect(templateSpy).to.not.have.been as any).called();
       })
       .not.to.throw();
   });
@@ -262,7 +263,7 @@ describe('ngWalker', () => {
     };
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new NgWalker(sf, ruleArgs);
-    (<any>chai)
+    chai
       .expect(() => {
         walker.walk(sf);
       })
@@ -287,7 +288,7 @@ describe('ngWalker', () => {
       };
       let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
       let walker = new NgWalker(sf, ruleArgs);
-      (<any>chai)
+      chai
         .expect(() => {
           walker.walk(sf);
         })
@@ -311,11 +312,11 @@ describe('ngWalker', () => {
       };
       let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
       let walker = new NgWalker(sf, ruleArgs);
-      (<any>chai)
+      chai
         .expect(() => {
           let templateSpy = chaiSpy.on(BasicCssAstVisitor.prototype, 'visitCssStyleSheet');
           walker.walk(sf);
-          (<any>chai.expect(templateSpy).to.have.been).called();
+          (chai.expect(templateSpy).to.have.been as any).called();
         })
         .not.to.throw();
     });
@@ -357,7 +358,7 @@ describe('ngWalker', () => {
       };
       let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
       let walker = new NgWalker(sf, ruleArgs);
-      (<any>chai)
+      chai
         .expect(() => {
           walker.walk(sf);
         })

--- a/test/angular/sourceMappingVisitor.spec.ts
+++ b/test/angular/sourceMappingVisitor.spec.ts
@@ -1,6 +1,6 @@
-import * as ts from 'typescript';
-import chai = require('chai');
+import { expect } from 'chai';
 import { renderSync } from 'node-sass';
+import * as ts from 'typescript';
 
 import { SourceMappingVisitor } from '../../src/angular/sourceMappingVisitor';
 import { getDecoratorPropertyInitializer } from '../../src/util/utils';
@@ -28,10 +28,10 @@ const last = <T extends ts.Node>(nodes: ts.NodeArray<T>) => nodes[nodes.length -
 describe('SourceMappingVisitor', () => {
   it('should map to correct position', () => {
     const ast = getAst(fixture1);
-    const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
+    const classDeclaration = last(ast.statements);
     const styles = getDecoratorPropertyInitializer(last(classDeclaration.decorators!), 'styles');
-    const styleNode = <ts.Node>styles.elements[0];
-    const scss = (<any>styleNode).text;
+    const styleNode = (styles as ts.ArrayLiteralExpression).elements[0];
+    const scss = (styleNode as any).text;
     const result = renderSync({ outFile: '/tmp/bar', data: scss, sourceMap: true });
     const visitor = new SourceMappingVisitor(
       ast,
@@ -50,7 +50,7 @@ describe('SourceMappingVisitor', () => {
     );
     visitor.addFailureAt(0, 3, 'bar');
     const failure = visitor.getFailures()[0];
-    chai.expect(failure.getStartPosition().getPosition()).eq(34);
-    chai.expect(failure.getEndPosition().getPosition()).eq(38);
+    expect(failure.getStartPosition().getPosition()).eq(34);
+    expect(failure.getEndPosition().getPosition()).eq(38);
   });
 });

--- a/test/angular/urlResolvers/urlResolver.spec.ts
+++ b/test/angular/urlResolvers/urlResolver.spec.ts
@@ -1,5 +1,5 @@
+import { expect } from 'chai';
 import * as ts from 'typescript';
-import chai = require('chai');
 
 import { AbstractResolver } from '../../../src/angular/urlResolvers/abstractResolver';
 
@@ -35,7 +35,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq('./foo/bar');
+      expect(template).eq('./foo/bar');
     });
 
     it('should be able to resolve templateUrls set with template string', () => {
@@ -48,7 +48,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq('./foo/bar');
+      expect(template).eq('./foo/bar');
     });
 
     it('should not be able to resolve templateUrls set with complex template string', () => {
@@ -61,7 +61,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq(undefined);
+      expect(template).eq(undefined);
     });
 
     it('should not be able to resolve missing templateUrl', () => {
@@ -74,7 +74,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq(undefined);
+      expect(template).eq(undefined);
     });
 
     it('should not be able to resolve templateUrls when having missing object literal', () => {
@@ -85,7 +85,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq(null);
+      expect(template).eq(undefined);
     });
 
     it('should not be able to resolve templateUrls when having missing object literal', () => {
@@ -96,7 +96,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const template = resolver.getTemplate(last(ast.statements).decorators![0]);
-      (<any>chai).expect(template).eq(null);
+      expect(template).eq(undefined);
     });
   });
 
@@ -109,7 +109,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const styles = resolver.getStyles(last(ast.statements).decorators![0]);
-      chai.expect(styles).to.deep.equal([]);
+      expect(styles).to.deep.equal([]);
     });
 
     it('should not be able to resolve styleUrls when having missing object literal', () => {
@@ -120,7 +120,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const styles = resolver.getStyles(last(ast.statements).decorators![0]);
-      chai.expect(styles).to.deep.equal([]);
+      expect(styles).to.deep.equal([]);
     });
 
     it('should be able to resolve styleUrls with string literal', () => {
@@ -136,7 +136,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const styles = resolver.getStyles(last(ast.statements).decorators![0]);
-      chai.expect(styles).to.deep.equal(['./foo', './bar']);
+      expect(styles).to.deep.equal(['./foo', './bar']);
     });
 
     it('should be able to resolve styleUrls with string literal', () => {
@@ -152,7 +152,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const styles = resolver.getStyles(last(ast.statements).decorators![0]);
-      chai.expect(styles).to.deep.equal(['./foo', './bar']);
+      expect(styles).to.deep.equal(['./foo', './bar']);
     });
 
     it('should ignore non-string literal urls', () => {
@@ -170,7 +170,7 @@ describe('urlResolver', () => {
       const ast = getAst(source);
       const resolver = new DummyResolver();
       const styles = resolver.getStyles(last(ast.statements).decorators![0]);
-      chai.expect(styles).to.deep.equal(['./foo', './bar']);
+      expect(styles).to.deep.equal(['./foo', './bar']);
     });
   });
 });

--- a/test/componentClassSuffixRule.spec.ts
+++ b/test/componentClassSuffixRule.spec.ts
@@ -95,7 +95,7 @@ describe('component-class-suffix', () => {
       assertSuccess('component-class-suffix', source, ['Page', 'View']);
     });
 
-    it('should fail when different list of suffix is set and doesnt match', function() {
+    it('should fail when different list of suffix is set and doesnt match', () => {
       let source = `
         @Component({
           selector: 'sgBarFoo'

--- a/test/noUnusedCssRule.spec.ts
+++ b/test/noUnusedCssRule.spec.ts
@@ -925,7 +925,7 @@ describe('no-unused-css', () => {
   });
 
   describe('invalid CSS', () => {
-    it('should work with non-matching quotes', function() {
+    it('should work with non-matching quotes', () => {
       let source = `
         @Component({
           selector: 'div[some-component]',
@@ -946,7 +946,7 @@ describe('no-unused-css', () => {
       assertSuccess('no-unused-css', source);
     });
 
-    it('should work with invalid CSS', function() {
+    it('should work with invalid CSS', () => {
       let source = `
         @Component({
           selector: 'div[some-component]',

--- a/test/testHelper.ts
+++ b/test/testHelper.ts
@@ -1,4 +1,4 @@
-import chai = require('chai');
+import { assert } from 'chai';
 import { ILinterOptions, IOptions, Linter, LintResult, RuleFailure } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
 import { loadRules, convertRuleOptions } from './utils';
@@ -236,13 +236,13 @@ export function assertFailure(
   try {
     result = lint(ruleName, source, options);
 
-    chai.assert(result.failures && result.failures.length > 0, 'no failures');
+    assert(result.failures && result.failures.length > 0, 'no failures');
 
     const ruleFail = result.failures[onlyNthFailure];
 
-    chai.assert.equal(fail.message, ruleFail.getFailure(), "error messages don't match");
-    chai.assert.deepEqual(fail.startPosition, ruleFail.getStartPosition().getLineAndCharacter(), "start char doesn't match");
-    chai.assert.deepEqual(fail.endPosition, ruleFail.getEndPosition().getLineAndCharacter(), "end char doesn't match");
+    assert.equal(fail.message, ruleFail.getFailure(), "error messages don't match");
+    assert.deepEqual(fail.startPosition, ruleFail.getStartPosition().getLineAndCharacter(), "start char doesn't match");
+    assert.deepEqual(fail.endPosition, ruleFail.getEndPosition().getLineAndCharacter(), "end char doesn't match");
 
     return result ? result.failures : undefined;
   } catch (e) {
@@ -268,11 +268,11 @@ export function assertFailures(ruleName: string, source: string | SourceFile, fa
     console.log(e.stack);
   }
 
-  chai.assert(result.failures && result.failures.length > 0, 'no failures');
+  assert(result.failures && result.failures.length > 0, 'no failures');
   result.failures.forEach((ruleFail, index) => {
-    chai.assert.equal(fails[index].message, ruleFail.getFailure(), "error messages don't match");
-    chai.assert.deepEqual(fails[index].startPosition, ruleFail.getStartPosition().getLineAndCharacter(), "start char doesn't match");
-    chai.assert.deepEqual(fails[index].endPosition, ruleFail.getEndPosition().getLineAndCharacter(), "end char doesn't match");
+    assert.equal(fails[index].message, ruleFail.getFailure(), "error messages don't match");
+    assert.deepEqual(fails[index].startPosition, ruleFail.getStartPosition().getLineAndCharacter(), "start char doesn't match");
+    assert.deepEqual(fails[index].endPosition, ruleFail.getEndPosition().getLineAndCharacter(), "end char doesn't match");
   });
 }
 
@@ -285,5 +285,5 @@ export function assertFailures(ruleName: string, source: string | SourceFile, fa
  */
 export function assertSuccess(ruleName: string, source: string | SourceFile, options?: any) {
   const result = lint(ruleName, source, options);
-  chai.assert.isTrue(result && result.failures.length === 0);
+  assert.isTrue(result && result.failures.length === 0);
 }

--- a/test/util/classDeclarationUtils.spec.ts
+++ b/test/util/classDeclarationUtils.spec.ts
@@ -1,10 +1,10 @@
+import { expect } from 'chai';
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 
 import { NgWalker } from '../../src/angular/ngWalker';
 import { getDeclaredMethodNames, getDeclaredPropertyNames } from '../../src/util/classDeclarationUtils';
 import { FlatSymbolTable } from '../../src/angular/templates/recursiveAngularExpressionVisitor';
-import chai = require('chai');
 
 describe('ngWalker', () => {
   it('should visit components and directives', () => {
@@ -34,7 +34,7 @@ describe('ngWalker', () => {
     let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
     let walker = new ClassUtilWalker(sf, ruleArgs);
     walker.walk(sf);
-    chai.expect(methods).to.deep.eq({ bar: true, baz: true });
-    chai.expect(properties).to.deep.eq({ foo: true });
+    expect(methods).to.deep.eq({ bar: true, baz: true });
+    expect(properties).to.deep.eq({ foo: true });
   });
 });


### PR DESCRIPTION
This:

- Replaces a lot of **any** usages with more expressive types;
- Uses type guard instead of (unnecessary) type casts;

PS: You can see that there are a lot more places that could be changed, but these or I can't replace, because changing them, breaks something or unfortunately it has to be **any**.