### PR TITLE
fix(no-output-on-prefix): fix regular expression

### DIFF
--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -34,7 +34,7 @@ class OutputWalker extends NgWalker {
     const className = getClassName(property);
     const memberName = property.name.getText();
 
-    if (!memberName || !/on((?![a-z])|(?=$))/.test(memberName)) {
+    if (!memberName || !/^on((?![a-z])|(?=$))/.test(memberName)) {
       return;
     }
 

--- a/test/noOutputOnPrefixRule.spec.ts
+++ b/test/noOutputOnPrefixRule.spec.ts
@@ -69,4 +69,16 @@ describe('no-output-on-prefix', () => {
       assertSuccess('no-output-on-prefix', source);
     });
   });
+
+  describe('valid output property name', () => {
+    it("should succeed, when a output property containing 'on' suffix", () => {
+      const source = `
+        @Component()
+        class SelectComponent {
+          @Output() selectionChanged = new EventEmitter<any>();
+        }
+      `;
+      assertSuccess('no-output-on-prefix', source);
+    });
+  });
 });

--- a/test/noOutputOnPrefixRule.spec.ts
+++ b/test/noOutputOnPrefixRule.spec.ts
@@ -68,10 +68,8 @@ describe('no-output-on-prefix', () => {
       `;
       assertSuccess('no-output-on-prefix', source);
     });
-  });
 
-  describe('valid output property name', () => {
-    it("should succeed, when a output property containing 'on' suffix", () => {
+    it("should succeed, when an output property containing 'on' suffix", () => {
       const source = `
         @Component()
         class SelectComponent {


### PR DESCRIPTION
this commit fixes incorrect behavior when memberName contains 'on' suffix in the word, for example selectionChanged.

```
/on((?![a-z])|(?=$))/.test('selectionChanged');
// true

/^on((?![a-z])|(?=$))/.test('selectionChanged');
// false
```