### PR TITLE
 fix: errors not being displayed in the correct files

### DIFF
--- a/src/angular/ngWalker.ts
+++ b/src/angular/ngWalker.ts
@@ -205,11 +205,8 @@ export class NgWalker extends Lint.RuleWalker {
     compiler.templateVisitAll(referenceVisitor, roots, null);
     visitor._variables = referenceVisitor.variables;
     roots.forEach(r => visitor.visit(r, context.controller));
-    visitor
-      .getFailures()
-      .forEach(f =>
-        this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
-      );
+    // tslint:disable-next-line:deprecation
+    visitor.getFailures().forEach(f => this.addFailure(f));
   }
 
   protected visitNgStyleHelper(style: CssAst, context: ComponentMetadata, styleMetadata: StyleMetadata, baseStart: number) {
@@ -220,11 +217,8 @@ export class NgWalker extends Lint.RuleWalker {
     const sourceFile = this.getContextSourceFile(styleMetadata.url!, styleMetadata.style.source!);
     const visitor = new this._config!.cssVisitorCtrl!(sourceFile, this._originalOptions, context, styleMetadata, baseStart);
     style.visit(visitor);
-    visitor
-      .getFailures()
-      .forEach(f =>
-        this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
-      );
+    // tslint:disable-next-line:deprecation
+    visitor.getFailures().forEach(f => this.addFailure(f));
   }
 
   protected getContextSourceFile(path: string, content: string) {

--- a/src/noUnusedCssRule.ts
+++ b/src/noUnusedCssRule.ts
@@ -289,11 +289,8 @@ export class UnusedCssNgVisitor extends NgWalker {
     const encapsulation = getDecoratorPropertyInitializer(d, 'encapsulation');
     if (isEncapsulationEnabled(encapsulation)) {
       style.visit(visitor);
-      visitor
-        .getFailures()
-        .forEach(f =>
-          this.addFailureFromStartToEnd(f.getStartPosition().getPosition(), f.getEndPosition().getPosition(), f.getFailure(), f.getFix())
-        );
+      // tslint:disable-next-line:deprecation
+      visitor.getFailures().forEach(f => this.addFailure(f));
     }
   }
 }


### PR DESCRIPTION
Fixes #692 #699.

It was a regression caused by PR #587. I'm not sure how we can add tests to prevent errors like this from popping up.