### PR TITLE
fix(no-unused-css): blank lines being left after fixing

### DIFF
--- a/src/noUnusedCssRule.ts
+++ b/src/noUnusedCssRule.ts
@@ -169,7 +169,7 @@ class UnusedCssVisitor extends BasicCssAstVisitor {
         } = ast;
         // length + 1 because we want to drop the '}'
         const length = endOffset - startOffset + 1;
-        this.addFailureAt(startOffset, length, 'Unused styles', this.createReplacement(startOffset, length, ''));
+        this.addFailureAt(startOffset, length, 'Unused styles', Lint.Replacement.deleteText(startOffset - 1, length + 1));
       }
     } catch (e) {
       logger.error(e);

--- a/test/noUnusedCssRule.spec.ts
+++ b/test/noUnusedCssRule.spec.ts
@@ -868,8 +868,8 @@ describe('no-unused-css', () => {
       )!;
       const replacement = failures[0].getFix() as Replacement;
       expect(replacement.text).to.eq('');
-      expect(replacement.start).to.eq(199);
-      expect(replacement.end).to.eq(246);
+      expect(replacement.start).to.eq(14);
+      expect(replacement.end).to.eq(62);
     });
 
     it('should work with SASS', () => {
@@ -919,8 +919,8 @@ describe('no-unused-css', () => {
       Config.transformStyle = (code: string) => ({ code, map: null });
       const replacement = failures[0].getFix() as Replacement;
       expect(replacement.text).to.eq('');
-      expect(replacement.start).to.eq(168);
-      expect(replacement.end).to.eq(271); // should be 276
+      expect(replacement.start).to.eq(-1);
+      expect(replacement.end).to.eq(29);
     });
   });
 


### PR DESCRIPTION
Currently, when you use `no-unused-css`'s *autofix*, it only replaces the unused classes with an empty string, which results in many blank lines. Sample:

**Input**:

```css
.test {
  color: #fff;
}
div{color: #fff;}
.test-2 {
  color: #fff;
}
.test-3 {color: #fff}
.test-4{                color:#fff;font-size: 12px;







}

button {
  color: #fff;
}

```

**Current output**:
```diff
- .test {
-   color: #fff;
- }
- div{color: #fff;}
- .test-2 {
-   color: #fff;
- }
- .test-3 {color: #fff}
- .test-4{                color:#fff;font-size: 12px;
- 
- 
- 

+ div{color: #fff;}



- }

button {
  color: #fff;
}

```

**Output using these changes**:

```diff
- .test {
-   color: #fff;
- }
- div{color: #fff;}
- .test-2 {
-   color: #fff;
- }
- .test-3 {color: #fff}
- .test-4{                color:#fff;font-size: 12px;
- 
- 
- 
- 
- 
-  
- }
+ div{color: #fff;}

button {
  color: #fff;
}

```