### PR TITLE
doc(readme): update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Create the following `tslint.json` file like:
     "use-life-cycle-interface": true,
     "contextual-life-cycle": true,
     "trackBy-function": true,
+    "relative-url-prefix": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
@@ -183,6 +184,7 @@ Now create the following `tslint.json` file where your `node_modules` directory 
     "use-life-cycle-interface": true,
     "contextual-life-cycle": true,
     "trackBy-function": true,
+    "relative-url-prefix": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
@@ -282,7 +284,7 @@ Below you can find a recommended configuration which is based on the [Angular St
   "enforce-component-selector": true,
   "no-queries-parameter": true,
   "prefer-inline-decorator": true,
-
+  "relative-url-prefix": true,
   // [ENABLED, "SUFFIX"]
   // Where "SUFFIX" is your custom suffix, for instance "Page" for Ionic 2 components.
   "component-class-suffix": [true, "Component"],
@@ -326,12 +328,13 @@ Below you can find a recommended configuration which is based on the [Angular St
 | `no-template-call-expression`          |     Stable     |
 | `no-queries-parameter`                 |     Stable     |
 | `prefer-inline-decorator`              |     Stable     |
+| `template-cyclomatic-complexity`       |     Stable     |
+| `relative-url-prefix`                  | _Experimental_ |
 | `no-conflicting-life-cycle-hooks`      | _Experimental_ |
 | `i18n`                                 | _Experimental_ |
 | `no-unused-css`                        | _Experimental_ |
-| `angular-whitespace`                   | _Experimental_ |
-| `template-cyclomatic-complexity`       | _Experimental_ |
 | `template-conditional-complexity`      | _Experimental_ |
+| `angular-whitespace`                   |  _Deprecated_  |
 | `pipe-naming`                          |  _Deprecated_  |
 
 ## Disable a rule that validates Template or Styles


### PR DESCRIPTION
Hi guys,

I've updated the readme with our new rule and I've taken some liberty with `Rules Status`, in particular with the rule 'angular-whitespace'. I think we never fix this rule due to the lack of information in the Angular compiler (CRLF, HTML entities, ...). Futhermore, Prettier fixes it fine now. 
It's just a proposal, what do you think ? 
  