### PR TITLE
fix(allow-template-call-expression): allow $any in expressions

### DIFF
--- a/src/noTemplateCallExpressionRule.ts
+++ b/src/noTemplateCallExpressionRule.ts
@@ -33,6 +33,8 @@ class TemplateVisitor extends BasicTemplateAstVisitor {
 }
 
 class ExpressionVisitor extends RecursiveAngularExpressionVisitor {
+  private allowedMethodNames = ['$any'];
+
   visitFunctionCall(node: e.FunctionCall, context: any) {
     this.addFailureFromStartToEnd(node.span.start, node.span.end, Rule.FAILURE_STRING);
 
@@ -40,7 +42,9 @@ class ExpressionVisitor extends RecursiveAngularExpressionVisitor {
   }
 
   visitMethodCall(node: e.MethodCall, context: any) {
-    this.addFailureFromStartToEnd(node.span.start, node.span.end, Rule.FAILURE_STRING);
+    if (this.allowedMethodNames.indexOf(node.name) === -1) {
+      this.addFailureFromStartToEnd(node.span.start, node.span.end, Rule.FAILURE_STRING);
+    }
 
     super.visitMethodCall(node, context);
   }

--- a/test/noTemplateCallExpressionRule.spec.ts
+++ b/test/noTemplateCallExpressionRule.spec.ts
@@ -21,6 +21,16 @@ describe('no-template-call-expression', () => {
       `;
       assertSuccess('no-template-call-expression', source);
     });
+
+    it('should allow $any to wrap unknown variables', () => {
+      let source = `
+        @Component({
+          template: '{{$any(info)}}'
+        })
+        class Bar {}
+      `;
+      assertSuccess('no-template-call-expression', source);
+    });
   });
 
   describe('failure', () => {


### PR DESCRIPTION
Hey Minko and co!

`$any` can be used to bypass issues with template typings when `fullTemplateTypeCheck` is on, but codelyzer doesn't seem to know about it, this PR fixes that

I'm not very familiar with how this project works so I've got a few open questions about my implementation:
1. Should the fix be applied in `visitFunctionCall` as well?
2. Should the fix be applied to the parent `RecursiveAngularExpressionVisitor` class instead?
3. Should a new rule be added (in a follow up PR) to disallow the use of `$any`, similar to the [tslint rule](https://palantir.github.io/tslint/rules/no-any/)?