### PR TITLE
refactor(rule): add deprecation message for 'angular-whitespace'

### DIFF
--- a/src/angularWhitespaceRule.ts
+++ b/src/angularWhitespaceRule.ts
@@ -279,6 +279,7 @@ class TemplateExpressionVisitor extends RecursiveAngularExpressionVisitor {
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
+    deprecationMessage: 'Use a formatter like Prettier for formatting purposes.',
     description: 'Ensures the proper formatting of Angular expressions.',
     hasFix: true,
     optionExamples: [


### PR DESCRIPTION
Once someone tries to use `angular-whitespace` rule will receive the following message: 

> angular-whitespace is deprecated. Use a formatter like Prettier for formatting purposes.