### PR TITLE
refactor: improve NgWalker and remove class name from error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,6 +582,22 @@
         }
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+        }
+      }
+    },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
@@ -636,6 +652,11 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -671,6 +692,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1740,6 +1769,11 @@
       "requires": {
         "array-find-index": "^1.0.1"
       }
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
     },
     "dargs": {
       "version": "4.1.0",

--- a/src/angular/metadata.ts
+++ b/src/angular/metadata.ts
@@ -44,3 +44,15 @@ export class ComponentMetadata extends DirectiveMetadata {
     super(controller, decorator, selector);
   }
 }
+
+export class PipeMetadata {
+  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator, public readonly name?: string) {}
+}
+
+export class ModuleMetadata {
+  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator, public readonly id?: string) {}
+}
+
+export class InjectableMetadata {
+  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator) {}
+}

--- a/src/componentClassSuffixRule.ts
+++ b/src/componentClassSuffixRule.ts
@@ -26,7 +26,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The name of the class %s should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
+  static readonly FAILURE_STRING = 'The name of a component should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
 
   static walkerBuilder: F2<ts.SourceFile, Lint.IOptions, NgWalker> = all(
     validateComponent((meta: ComponentMetadata, suffixList: string[] = []) =>
@@ -38,7 +38,7 @@ export class Rule extends Lint.Rules.AbstractRule {
           const suffixes = suffixList.length > 0 ? suffixList : ['Component'];
 
           if (!Rule.validate(text, suffixes)) {
-            failures.push(new Failure(name!, sprintf(Rule.FAILURE_STRING, text, suffixes)));
+            failures.push(new Failure(name!, sprintf(Rule.FAILURE_STRING, suffixes)));
           }
 
           return failures;

--- a/src/componentSelectorRule.ts
+++ b/src/componentSelectorRule.ts
@@ -69,18 +69,18 @@ export class Rule extends SelectorRule {
 
   getPrefixFailure(prefixes: string[]): string {
     if (prefixes.length === 1) {
-      return 'The selector of the component "%s" should have prefix "%s" (https://angular.io/styleguide#style-02-07)';
+      return 'The selector of a component should have prefix "%s" (https://angular.io/styleguide#style-02-07)';
     } else {
-      return 'The selector of the component "%s" should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-07)';
+      return 'The selector of a component should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-07)';
     }
   }
 
   getStyleFailure(): string {
-    return 'The selector of the component "%s" should be named %s (https://angular.io/styleguide#style-05-02)';
+    return 'The selector of a component should be named %s (https://angular.io/styleguide#style-05-02)';
   }
 
   getTypeFailure(): string {
-    return 'The selector of the component "%s" should be used as %s (https://angular.io/styleguide#style-05-03)';
+    return 'The selector of a component should be used as %s (https://angular.io/styleguide#style-05-03)';
   }
 
   isEnabled(): boolean {

--- a/src/contextualDecoratorRule.ts
+++ b/src/contextualDecoratorRule.ts
@@ -15,13 +15,12 @@ import {
 } from './util/utils';
 
 interface FailureParameters {
-  readonly className: string;
   readonly decoratorName: DecoratorKeys;
   readonly metadataType: MetadataTypes;
 }
 
 export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(Rule.FAILURE_STRING, failureParameters.decoratorName, failureParameters.className, failureParameters.metadataType);
+  sprintf(Rule.FAILURE_STRING, failureParameters.decoratorName, failureParameters.metadataType);
 
 export class Rule extends AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -36,7 +35,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The decorator "%s" is not allowed for class "%s" because it is decorated with "%s"';
+  static readonly FAILURE_STRING = 'The decorator "%s" is not allowed for a class decorated with "%s"';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new ContextualDecoratorWalker(sourceFile, this.getOptions()));
@@ -74,8 +73,7 @@ export class ContextualDecoratorWalker extends NgWalker {
 
     if (!allowedDecorators || allowedDecorators.has(decoratorName)) return;
 
-    const className = klass.name.getText();
-    const failure = getFailureMessage({ className, decoratorName, metadataType });
+    const failure = getFailureMessage({ decoratorName, metadataType });
 
     this.addFailureAtNode(decorator, failure);
   }

--- a/src/contextualLifecycleRule.ts
+++ b/src/contextualLifecycleRule.ts
@@ -15,13 +15,7 @@ import {
 } from './util/utils';
 import { InjectableMetadata, PipeMetadata } from './angular';
 
-interface FailureParameters {
-  readonly metadataType: MetadataTypeKeys;
-  readonly methodName: LifecycleMethodKeys;
-}
-
-export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(Rule.FAILURE_STRING, failureParameters.methodName, failureParameters.metadataType);
+export const getFailureMessage = (metadataType: MetadataTypeKeys): string => sprintf(Rule.FAILURE_STRING, metadataType);
 
 export class Rule extends AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -36,7 +30,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The method "%s" is not allowed for a class decorated with "%s"';
+  static readonly FAILURE_STRING = 'This method is not allowed for a class decorated with "%s"';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new ContextualLifecycleWalker(sourceFile, this.getOptions()));
@@ -68,7 +62,7 @@ class ContextualLifecycleWalker extends NgWalker {
 
       if (!isLifecycleMethod(methodName) || allowedMethods.has(methodName)) continue;
 
-      const failure = getFailureMessage({ metadataType, methodName });
+      const failure = getFailureMessage(metadataType);
 
       this.addFailureAtNode(member, failure);
     }

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -27,7 +27,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The name of the class %s should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
+  static readonly FAILURE_STRING = 'The name of a directive should end with the suffix %s (https://angular.io/styleguide#style-02-03)';
 
   static validate(className: string, suffixes: string[]): boolean {
     return suffixes.some(s => className.endsWith(s));
@@ -61,7 +61,7 @@ export class ClassMetadataWalker extends NgWalker {
     }
 
     if (!Rule.validate(className, suffixes)) {
-      this.addFailureAtNode(name, sprintf(Rule.FAILURE_STRING, className, suffixes.join(', ')));
+      this.addFailureAtNode(name, sprintf(Rule.FAILURE_STRING, suffixes.join(', ')));
     }
 
     super.visitNgDirective(metadata);

--- a/src/directiveSelectorRule.ts
+++ b/src/directiveSelectorRule.ts
@@ -62,18 +62,18 @@ export class Rule extends SelectorRule {
 
   getPrefixFailure(prefixes: string[]): string {
     if (prefixes.length === 1) {
-      return 'The selector of the directive "%s" should have prefix "%s" (https://angular.io/styleguide#style-02-08)';
+      return 'The selector of a directive should have prefix "%s" (https://angular.io/styleguide#style-02-08)';
     } else {
-      return 'The selector of the directive "%s" should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-08)';
+      return 'The selector of a directive should have one of the prefixes "%s" (https://angular.io/styleguide#style-02-08)';
     }
   }
 
   getStyleFailure(): string {
-    return 'The selector of the directive "%s" should be named %s (https://angular.io/styleguide#style-02-06)';
+    return 'The selector of a directive should be named %s (https://angular.io/styleguide#style-02-06)';
   }
 
   getTypeFailure(): string {
-    return 'The selector of the directive "%s" should be used as %s (https://angular.io/styleguide#style-02-06)';
+    return 'The selector of a directive should be used as %s (https://angular.io/styleguide#style-02-06)';
   }
 
   isEnabled(): boolean {

--- a/src/noAttributeParameterDecoratorRule.ts
+++ b/src/noAttributeParameterDecoratorRule.ts
@@ -18,33 +18,25 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   static readonly FAILURE_STRING =
-    'In the constructor of class "%s", the parameter "%s" uses the @Attribute decorator, which is considered as a bad practice. Please, consider construction of type "@Input() %s: string"';
+    'In the constructor of a directive, the parameter "%s" uses the @Attribute decorator, which is considered as a bad practice. Please, consider construction of type "@Input() %s: string"';
 
   private static readonly walkerBuilder = all(
     validate(ts.SyntaxKind.Constructor)(node => {
-      return Maybe.lift(node.parent)
-        .fmap(parent => {
-          if (parent && ts.isClassExpression(parent) && (parent.parent as any).name) {
-            return (parent.parent as any).name.text;
-          } else if (parent && ts.isClassDeclaration(parent)) {
-            return parent.name!.text;
-          }
-        })
-        .bind(parentName => {
-          const failures: Maybe<Failure | undefined>[] = (node as any).parameters.map(p => {
-            const text = p.name.getText();
+      return Maybe.lift(node.parent).bind(() => {
+        const failures: Maybe<Failure | undefined>[] = (node as any).parameters.map(p => {
+          const text = p.name.getText();
 
-            return Maybe.lift(p.decorators).bind(decorators => {
-              // Check if any @Attribute
-              const decoratorsFailed = listToMaybe(decorators.map(d => Rule.decoratorIsAttribute(d)));
+          return Maybe.lift(p.decorators).bind(decorators => {
+            // Check if any @Attribute
+            const decoratorsFailed = listToMaybe(decorators.map(d => Rule.decoratorIsAttribute(d)));
 
-              // We only care about 1 since we highlight the whole 'parameter'
-              return (decoratorsFailed as any).fmap(() => new Failure(p, sprintf(Rule.FAILURE_STRING, parentName, text, text)));
-            });
+            // We only care about 1 since we highlight the whole 'parameter'
+            return (decoratorsFailed as any).fmap(() => new Failure(p, sprintf(Rule.FAILURE_STRING, text, text)));
           });
-
-          return listToMaybe(failures) as any;
         });
+
+        return listToMaybe(failures) as any;
+      });
     })
   );
 

--- a/src/noConflictingLifecycleRule.ts
+++ b/src/noConflictingLifecycleRule.ts
@@ -1,4 +1,3 @@
-import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, RuleWalker } from 'tslint';
 import { AbstractRule } from 'tslint/lib/rules';
 import { dedent } from 'tslint/lib/utils';
@@ -13,16 +12,8 @@ import {
   LifecycleMethods
 } from './util/utils';
 
-interface FailureParameters {
-  readonly className: string;
-  readonly message: typeof Rule.FAILURE_STRING_INTERFACE_HOOK | typeof Rule.FAILURE_STRING_METHOD_HOOK;
-}
-
 const LIFECYCLE_INTERFACES: ReadonlyArray<LifecycleInterfaceKeys> = [LifecycleInterfaces.DoCheck, LifecycleInterfaces.OnChanges];
 const LIFECYCLE_METHODS: ReadonlyArray<LifecycleMethodKeys> = [LifecycleMethods.ngDoCheck, LifecycleMethods.ngOnChanges];
-
-export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(failureParameters.message, failureParameters.className);
 
 export class Rule extends AbstractRule {
   static metadata: IRuleMetadata = {
@@ -41,10 +32,10 @@ export class Rule extends AbstractRule {
   };
 
   static readonly FAILURE_STRING_INTERFACE_HOOK = dedent`
-    Implementing ${LifecycleInterfaces.DoCheck} and ${LifecycleInterfaces.OnChanges} in class %s is not recommended
+    Implementing ${LifecycleInterfaces.DoCheck} and ${LifecycleInterfaces.OnChanges} in a directive is not recommended
   `;
   static readonly FAILURE_STRING_METHOD_HOOK = dedent`
-    Declaring ${LifecycleMethods.ngDoCheck} and ${LifecycleMethods.ngOnChanges} method in class %s is not recommended
+    Declaring ${LifecycleMethods.ngDoCheck} and ${LifecycleMethods.ngOnChanges} method in a directive is not recommended
   `;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
@@ -68,10 +59,7 @@ class ClassMetadataWalker extends RuleWalker {
 
     if (!className || !hasConflictingLifecycle) return;
 
-    const failure = getFailureMessage({
-      className,
-      message: Rule.FAILURE_STRING_INTERFACE_HOOK
-    });
+    const failure = Rule.FAILURE_STRING_INTERFACE_HOOK;
 
     this.addFailureAtNode(node, failure);
   }
@@ -83,10 +71,7 @@ class ClassMetadataWalker extends RuleWalker {
 
     if (!className || !hasConflictingLifecycle) return;
 
-    const failure = getFailureMessage({
-      className,
-      message: Rule.FAILURE_STRING_METHOD_HOOK
-    });
+    const failure = Rule.FAILURE_STRING_METHOD_HOOK;
 
     this.addFailureAtNode(node, failure);
   }

--- a/src/noForwardRefRule.ts
+++ b/src/noForwardRefRule.ts
@@ -4,15 +4,7 @@ import { AbstractRule } from 'tslint/lib/rules';
 import { CallExpression, isClassDeclaration, isVariableStatement, SourceFile } from 'typescript/lib/typescript';
 import { getNextToLastParentNode } from './util/utils';
 
-interface FailureParameters {
-  readonly className: string;
-  readonly message: typeof Rule.FAILURE_STRING_CLASS | typeof Rule.FAILURE_STRING_VARIABLE;
-}
-
 export const FORWARD_REF = 'forwardRef';
-
-export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(failureParameters.message, failureParameters.className);
 
 export class Rule extends AbstractRule {
   static metadata: IRuleMetadata = {
@@ -25,7 +17,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING_CLASS = `Avoid using \`${FORWARD_REF}\` in class "%s"`;
+  static readonly FAILURE_STRING_CLASS = `Avoid using \`${FORWARD_REF}\` in a class`;
   static readonly FAILURE_STRING_VARIABLE = `Avoid using \`${FORWARD_REF}\` in variable "%s"`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
@@ -46,15 +38,9 @@ export class NoForwardRefWalker extends RuleWalker {
     let failure: ReturnType<typeof sprintf>;
 
     if (isVariableStatement(nextToLastParent)) {
-      failure = getFailureMessage({
-        className: nextToLastParent.declarationList.declarations[0].name.getText(),
-        message: Rule.FAILURE_STRING_VARIABLE
-      });
+      failure = Rule.FAILURE_STRING_VARIABLE;
     } else if (isClassDeclaration(nextToLastParent) && nextToLastParent.name) {
-      failure = getFailureMessage({
-        className: nextToLastParent.name.text,
-        message: Rule.FAILURE_STRING_CLASS
-      });
+      failure = Rule.FAILURE_STRING_CLASS;
     } else {
       return;
     }

--- a/src/noInputRenameRule.ts
+++ b/src/noInputRenameRule.ts
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   static readonly FAILURE_STRING = Lint.Utils.dedent`
-    The directive input property "%s" should not be renamed.
+    The directive input property should not be renamed.
     However, you should use an alias when the directive name is also an input property, and the directive name
     doesn't describe the property. In this last case, you can disable this rule with \`tslint:disable-next-line:no-input-rename\`.
   `;
@@ -28,8 +28,8 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-export const getFailureMessage = (propertyName: string): string => {
-  return sprintf(Rule.FAILURE_STRING, propertyName);
+export const getFailureMessage = (): string => {
+  return sprintf(Rule.FAILURE_STRING);
 };
 
 // source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
@@ -101,6 +101,6 @@ export class InputMetadataWalker extends NgWalker {
       return;
     }
 
-    this.addFailureAtNode(property, getFailureMessage(memberName));
+    this.addFailureAtNode(property, getFailureMessage());
   }
 }

--- a/src/noInputRenameRule.ts
+++ b/src/noInputRenameRule.ts
@@ -3,7 +3,7 @@ import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { DirectiveMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
-import { getClassName, kebabToCamelCase, toTitleCase } from './util/utils';
+import { kebabToCamelCase, toTitleCase } from './util/utils';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -18,7 +18,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   };
 
   static readonly FAILURE_STRING = Lint.Utils.dedent`
-    In the class "%s", the directive input property "%s" should not be renamed.
+    The directive input property "%s" should not be renamed.
     However, you should use an alias when the directive name is also an input property, and the directive name
     doesn't describe the property. In this last case, you can disable this rule with \`tslint:disable-next-line:no-input-rename\`.
   `;
@@ -28,8 +28,8 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-export const getFailureMessage = (className: string, propertyName: string): string => {
-  return sprintf(Rule.FAILURE_STRING, className, propertyName);
+export const getFailureMessage = (propertyName: string): string => {
+  return sprintf(Rule.FAILURE_STRING, propertyName);
 };
 
 // source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
@@ -95,13 +95,12 @@ export class InputMetadataWalker extends NgWalker {
   }
 
   private validateInput(property: ts.PropertyDeclaration, args: string[]) {
-    const className = getClassName(property)!;
     const memberName = property.name.getText();
 
     if (args.length === 0 || this.canPropertyBeAliased(args[0], memberName)) {
       return;
     }
 
-    this.addFailureAtNode(property, getFailureMessage(className, memberName));
+    this.addFailureAtNode(property, getFailureMessage(memberName));
   }
 }

--- a/src/noOutputNativeRule.ts
+++ b/src/noOutputNativeRule.ts
@@ -198,7 +198,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The output property "%s" should not be named or renamed as a native event';
+  static readonly FAILURE_STRING = 'Output property should not be named or renamed as a native event';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new NoOutputNativeWalker(sourceFile, this.getOptions()));

--- a/src/noOutputNativeRule.ts
+++ b/src/noOutputNativeRule.ts
@@ -6,7 +6,6 @@ import { NgWalker } from './angular/ngWalker';
 import { getClassName } from './util/utils';
 
 interface FailureParameters {
-  readonly className: string;
   readonly propertyName: string;
 }
 
@@ -186,7 +185,7 @@ const nativeEventNames: ReadonlySet<string> = new Set([
 ]);
 
 export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(Rule.FAILURE_STRING, failureParameters.className, failureParameters.propertyName);
+  sprintf(Rule.FAILURE_STRING, failureParameters.propertyName);
 
 export class Rule extends AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -199,7 +198,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be named or renamed as a native event';
+  static readonly FAILURE_STRING = 'The output property "%s" should not be named or renamed as a native event';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new NoOutputNativeWalker(sourceFile, this.getOptions()));
@@ -222,7 +221,7 @@ class NoOutputNativeWalker extends NgWalker {
 
     if (!outputName || !nativeEventNames.has(outputName)) return;
 
-    const failure = getFailureMessage({ className, propertyName });
+    const failure = getFailureMessage({ propertyName });
 
     this.addFailureAtNode(property, failure);
   }

--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -2,7 +2,6 @@ import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { NgWalker } from './angular/ngWalker';
-import { getClassName } from './util/utils';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -17,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be prefixed with on';
+  static readonly FAILURE_STRING = 'The output property "%s" should not be prefixed with on';
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new OutputWalker(sourceFile, this.getOptions()));
@@ -31,14 +30,13 @@ class OutputWalker extends NgWalker {
   }
 
   private validateOutput(property: ts.PropertyDeclaration): void {
-    const className = getClassName(property);
     const memberName = property.name.getText();
 
     if (!memberName || !/^on((?![a-z])|(?=$))/.test(memberName)) {
       return;
     }
 
-    const failure = sprintf(Rule.FAILURE_STRING, className, memberName);
+    const failure = sprintf(Rule.FAILURE_STRING, memberName);
 
     this.addFailureAtNode(property, failure);
   }

--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The output property "%s" should not be prefixed with on';
+  static readonly FAILURE_STRING = 'Output property should not be prefixed with on';
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithWalker(new OutputWalker(sourceFile, this.getOptions()));

--- a/src/noOutputRenameRule.ts
+++ b/src/noOutputRenameRule.ts
@@ -22,10 +22,6 @@ export class Rule extends Rules.AbstractRule {
   }
 }
 
-export const getFailureMessage = (): string => {
-  return Rule.FAILURE_STRING;
-};
-
 export class OutputMetadataWalker extends NgWalker {
   private directiveSelectors!: ReadonlySet<DirectiveMetadata['selector']>;
 
@@ -50,6 +46,6 @@ export class OutputMetadataWalker extends NgWalker {
       return;
     }
 
-    this.addFailureAtNode(property, getFailureMessage());
+    this.addFailureAtNode(property, Rule.FAILURE_STRING);
   }
 }

--- a/src/pipePrefixRule.ts
+++ b/src/pipePrefixRule.ts
@@ -28,7 +28,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static FAILURE_STRING = `The name of a Pipe decorator should start with prefix %s, however its value is "%s"`;
+  static FAILURE_STRING = `The name of a Pipe decorator should start with prefix %s`;
 
   prefix: string;
   private prefixChecker: Function;
@@ -89,7 +89,7 @@ export class ClassMetadataWalker extends NgWalker {
       const isValid = this.rule.validatePrefix(propName);
 
       if (!isValid) {
-        this.addFailureAtNode(property, sprintf(Rule.FAILURE_STRING, this.rule.prefix, propName));
+        this.addFailureAtNode(property, sprintf(Rule.FAILURE_STRING, this.rule.prefix));
       }
     }
   }

--- a/src/useComponentSelectorRule.ts
+++ b/src/useComponentSelectorRule.ts
@@ -5,12 +5,7 @@ import { SourceFile } from 'typescript';
 import { ComponentMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
 
-interface FailureParameters {
-  readonly className: string;
-}
-
-export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(Rule.FAILURE_STRING, failureParameters.className);
+export const getFailureMessage = (): string => sprintf(Rule.FAILURE_STRING);
 
 export class Rule extends AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -23,7 +18,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The selector of the component "%s" is mandatory';
+  static readonly FAILURE_STRING = 'A component must have a selector';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new UseComponentSelectorValidatorWalker(sourceFile, this.getOptions()));
@@ -45,7 +40,7 @@ class UseComponentSelectorValidatorWalker extends NgWalker {
 
     if (metadataSelector || !controllerName) return;
 
-    const failure = getFailureMessage({ className: controllerName.text });
+    const failure = getFailureMessage();
 
     this.addFailureAtNode(metadataDecorator, failure);
   }

--- a/src/useLifecycleInterfaceRule.ts
+++ b/src/useLifecycleInterfaceRule.ts
@@ -4,7 +4,6 @@ import { AbstractRule } from 'tslint/lib/rules';
 import { ClassDeclaration, SourceFile } from 'typescript';
 import { getDeclaredMethods } from './util/classDeclarationUtils';
 import {
-  getClassName,
   getDeclaredLifecycleInterfaces,
   isLifecycleMethod,
   LifecycleInterfaceKeys,
@@ -13,7 +12,6 @@ import {
 } from './util/utils';
 
 interface FailureParameters {
-  readonly className: string;
   readonly interfaceName: LifecycleInterfaceKeys;
   readonly methodName: LifecycleMethodKeys;
 }
@@ -21,7 +19,7 @@ interface FailureParameters {
 const STYLE_GUIDE_LINK = 'https://angular.io/styleguide#style-09-01';
 
 export const getFailureMessage = (failureParameters: FailureParameters): string =>
-  sprintf(Rule.FAILURE_STRING, failureParameters.interfaceName, failureParameters.methodName, failureParameters.className);
+  sprintf(Rule.FAILURE_STRING, failureParameters.interfaceName, failureParameters.methodName);
 
 export class Rule extends AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -35,7 +33,7 @@ export class Rule extends AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = `Implement lifecycle interface %s for method %s in class %s (${STYLE_GUIDE_LINK})`;
+  static readonly FAILURE_STRING = `Implement lifecycle interface %s for method %s in this class (${STYLE_GUIDE_LINK})`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
     return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this.getOptions()));
@@ -49,10 +47,6 @@ class ClassMetadataWalker extends RuleWalker {
   }
 
   private validateClassDeclaration(node: ClassDeclaration): void {
-    const className = getClassName(node);
-
-    if (!className) return;
-
     const declaredLifecycleInterfaces = getDeclaredLifecycleInterfaces(node);
     const declaredMethods = getDeclaredMethods(node);
 
@@ -67,7 +61,7 @@ class ClassMetadataWalker extends RuleWalker {
 
       if (isMethodImplemented) continue;
 
-      const failure = getFailureMessage({ className, interfaceName, methodName });
+      const failure = getFailureMessage({ interfaceName, methodName });
 
       this.addFailureAtNode(methodProperty, failure);
     }

--- a/src/usePipeDecoratorRule.ts
+++ b/src/usePipeDecoratorRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The %s class implements the PipeTransform interface, so it should use the @Pipe decorator';
+  static readonly FAILURE_STRING = 'A class which implements the PipeTransform interface should use the @Pipe decorator';
   static readonly PIPE_INTERFACE_NAME = 'PipeTransform';
 
   apply(sourceFile: SourceFile): RuleFailure[] {

--- a/src/usePipeDecoratorRule.ts
+++ b/src/usePipeDecoratorRule.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules, RuleWalker } from 'tslint/lib';
 import { ClassDeclaration, SourceFile, SyntaxKind } from 'typescript/lib/typescript';
-import { getDecoratorName, getSymbolName } from './util/utils';
+import { getClassName, getDecoratorName, getSymbolName } from './util/utils';
 
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -45,10 +45,13 @@ export class ClassMetadataWalker extends RuleWalker {
   }
 
   private validateClassDeclaration(node: ClassDeclaration) {
+    const className = getClassName(node);
+    if (!className) return;
+
     if (!hasPipeTransform(node) || hasPipe(node)) {
       return;
     }
 
-    this.addFailureAtNode(node, sprintf(Rule.FAILURE_STRING, node.name!.text));
+    this.addFailureAtNode(node, sprintf(Rule.FAILURE_STRING, className));
   }
 }

--- a/src/usePipeTransformInterfaceRule.ts
+++ b/src/usePipeTransformInterfaceRule.ts
@@ -14,7 +14,7 @@ export class Rule extends Rules.AbstractRule {
     typescriptOnly: true
   };
 
-  static readonly FAILURE_STRING = 'The %s class has the Pipe decorator, so it should implement the PipeTransform interface';
+  static readonly FAILURE_STRING = 'A class which has the Pipe decorator should implement the PipeTransform interface';
   static readonly PIPE_INTERFACE_NAME = 'PipeTransform';
 
   apply(sourceFile: SourceFile): RuleFailure[] {

--- a/src/usePipeTransformInterfaceRule.ts
+++ b/src/usePipeTransformInterfaceRule.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules, RuleWalker } from 'tslint/lib';
 import { ClassDeclaration, SourceFile, SyntaxKind } from 'typescript/lib/typescript';
-import { getDecoratorName, getSymbolName } from './util/utils';
+import { getClassName, getDecoratorName, getSymbolName } from './util/utils';
 
 export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
@@ -45,10 +45,13 @@ export class ClassMetadataWalker extends RuleWalker {
   }
 
   private validateClassDeclaration(node: ClassDeclaration) {
+    const className = getClassName(node);
+    if (!className) return;
+
     if (!hasPipe(node) || hasPipeTransform(node)) {
       return;
     }
 
-    this.addFailureAtNode(node, sprintf(Rule.FAILURE_STRING, node.name!.text));
+    this.addFailureAtNode(node, sprintf(Rule.FAILURE_STRING, className));
   }
 }

--- a/test/angular/ngWalker.spec.ts
+++ b/test/angular/ngWalker.spec.ts
@@ -28,10 +28,6 @@ describe('ngWalker', () => {
         name: 'foo'
       })
       class FooPipe {}
-      @NgModule({})
-      class BarModule {}
-      @Injectable()
-      class FooService {}
     `;
     let ruleArgs: Lint.IOptions = {
       ruleName: 'foo',
@@ -44,14 +40,10 @@ describe('ngWalker', () => {
     let cmpSpy = chaiSpy.on(walker, 'visitNgComponent');
     let dirSpy = chaiSpy.on(walker, 'visitNgDirective');
     let pipeSpy = chaiSpy.on(walker, 'visitNgPipe');
-    let modSpy = chaiSpy.on(walker, 'visitNgModule');
-    let injSpy = chaiSpy.on(walker, 'visitNgInjectable');
     walker.walk(sf);
     (chai.expect(cmpSpy).to.have.been as any).called();
     (chai.expect(dirSpy).to.have.been as any).called();
     (chai.expect(pipeSpy).to.have.been as any).called();
-    (chai.expect(modSpy).to.have.been as any).called();
-    (chai.expect(injSpy).to.have.been as any).called();
   });
 
   it('should visit inputs and outputs with args', () => {

--- a/test/angularWhitespaceRule.spec.ts
+++ b/test/angularWhitespaceRule.spec.ts
@@ -1074,4 +1074,10 @@ describe('angular-whitespace multiple checks', () => {
       `);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('angular-whitespace', source, ['check-interpolation', 'check-pipe']);
+    });
+  });
 });

--- a/test/componentClassSuffixRule.spec.ts
+++ b/test/componentClassSuffixRule.spec.ts
@@ -12,7 +12,7 @@ describe('component-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'component-class-suffix',
-        message: 'The name of the class Test should end with the suffix Component (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a component should end with the suffix Component (https://angular.io/styleguide#style-02-03)',
         source
       });
     });
@@ -73,7 +73,12 @@ describe('component-class-suffix', () => {
       assertSuccess('component-class-suffix', source);
     });
   });
-
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('component-class-suffix', source);
+    });
+  });
   describe('changed suffix', () => {
     it('should succeed when different suffix is set', () => {
       let source = `
@@ -105,8 +110,7 @@ describe('component-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'component-class-suffix',
-        message:
-          'The name of the class TestPage should end with the suffix Component,View' + ' (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a component should end with the suffix Component,View' + ' (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Component', 'View']
       });
@@ -122,7 +126,7 @@ describe('component-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'component-class-suffix',
-        message: 'The name of the class TestPage should end with the suffix Component (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a component should end with the suffix Component (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Component']
       });
@@ -138,7 +142,7 @@ describe('component-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'component-class-suffix',
-        message: 'The name of the class TestDirective should end with the suffix Page (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a component should end with the suffix Page (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Page']
       });

--- a/test/componentMaxInlineDeclarationsRule.spec.ts
+++ b/test/componentMaxInlineDeclarationsRule.spec.ts
@@ -306,4 +306,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, getSourceFile(source));
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/componentSelectorRule.spec.ts
+++ b/test/componentSelectorRule.spec.ts
@@ -12,7 +12,7 @@ describe('component-selector-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'component-selector',
-        message: 'The selector of the component "Test" should have prefix "sg" (https://angular.io/styleguide#style-02-07)',
+        message: 'The selector of a component should have prefix "sg" (https://angular.io/styleguide#style-02-07)',
         source,
         options: ['element', 'sg', 'kebab-case']
       });
@@ -29,8 +29,7 @@ describe('component-selector-prefix', () => {
       assertAnnotated({
         ruleName: 'component-selector',
         message:
-          'The selector of the component "Test" should have one of the prefixes "sg, mg, ng"' +
-          ' (https://angular.io/styleguide#style-02-07)',
+          'The selector of a component should have one of the prefixes "sg, mg, ng"' + ' (https://angular.io/styleguide#style-02-07)',
         source,
         options: ['element', ['sg', 'mg', 'ng'], 'kebab-case']
       });
@@ -46,8 +45,7 @@ describe('component-selector-prefix', () => {
       assertAnnotated({
         ruleName: 'component-selector',
         message:
-          'The selector of the component "Test" should have one of the prefixes "sg, mg, ng"' +
-          ' (https://angular.io/styleguide#style-02-07)',
+          'The selector of a component should have one of the prefixes "sg, mg, ng"' + ' (https://angular.io/styleguide#style-02-07)',
         source,
         options: ['element', ['sg', 'mg', 'ng'], 'kebab-case']
       });
@@ -65,15 +63,11 @@ describe('component-selector-prefix', () => {
         failures: [
           {
             char: '~',
-            msg:
-              'The selector of the component "TestOne" should have one of the prefixes "fo, mg, ng"' +
-              ' (https://angular.io/styleguide#style-02-07)'
+            msg: 'The selector of a component should have one of the prefixes "fo, mg, ng"' + ' (https://angular.io/styleguide#style-02-07)'
           },
           {
             char: '^',
-            msg:
-              'The selector of the component "TestTwo" should have one of the prefixes "fo, mg, ng"' +
-              ' (https://angular.io/styleguide#style-02-07)'
+            msg: 'The selector of a component should have one of the prefixes "fo, mg, ng"' + ' (https://angular.io/styleguide#style-02-07)'
           }
         ],
         source,
@@ -157,7 +151,7 @@ describe('component-selector-type', () => {
       `;
       assertAnnotated({
         ruleName: 'component-selector',
-        message: 'The selector of the component "Test" should be used as element (https://angular.io/styleguide#style-05-03)',
+        message: 'The selector of a component should be used as element (https://angular.io/styleguide#style-05-03)',
         source,
         options: ['element', ['sg', 'ng'], 'kebab-case']
       });
@@ -173,7 +167,7 @@ describe('component-selector-type', () => {
       `;
       assertAnnotated({
         ruleName: 'component-selector',
-        message: 'The selector of the component "Test" should be used as element (https://angular.io/styleguide#style-05-03)',
+        message: 'The selector of a component should be used as element (https://angular.io/styleguide#style-05-03)',
         source,
         options: ['element', ['sg', 'ng'], 'kebab-case']
       });
@@ -235,9 +229,7 @@ describe('component-selector-name', () => {
       `;
       assertAnnotated({
         ruleName: 'component-selector',
-        message:
-          'The selector of the component "Test" should be named kebab-case and include dash ' +
-          '(https://angular.io/styleguide#style-05-02)',
+        message: 'The selector of a component should be named kebab-case and include dash ' + '(https://angular.io/styleguide#style-05-02)',
         source,
         options: ['element', 'sg', 'kebab-case']
       });
@@ -253,9 +245,7 @@ describe('component-selector-name', () => {
       `;
       assertAnnotated({
         ruleName: 'component-selector',
-        message:
-          'The selector of the component "Test" should be named kebab-case and include dash ' +
-          '(https://angular.io/styleguide#style-05-02)',
+        message: 'The selector of a component should be named kebab-case and include dash ' + '(https://angular.io/styleguide#style-05-02)',
         source,
         options: ['element', 'sg', 'kebab-case']
       });
@@ -296,6 +286,12 @@ describe('component-selector-name', () => {
         })
         class Test {}
       `;
+      assertSuccess('component-selector', source, ['attribute', 'sg', 'camelCase']);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess('component-selector', source, ['attribute', 'sg', 'camelCase']);
     });
   });

--- a/test/contextualDecoratorRule.spec.ts
+++ b/test/contextualDecoratorRule.spec.ts
@@ -19,7 +19,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ContentChild,
             metadataType: MetadataTypes.Injectable
           }),
@@ -38,7 +37,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ContentChildren,
             metadataType: MetadataTypes.Injectable
           }),
@@ -57,7 +55,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.HostBinding,
             metadataType: MetadataTypes.Injectable
           }),
@@ -79,7 +76,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.HostListener,
             metadataType: MetadataTypes.Injectable
           }),
@@ -98,7 +94,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.Input,
             metadataType: MetadataTypes.Injectable
           }),
@@ -117,7 +112,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.Output,
             metadataType: MetadataTypes.Injectable
           }),
@@ -136,7 +130,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ViewChild,
             metadataType: MetadataTypes.Injectable
           }),
@@ -155,7 +148,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ViewChildren,
             metadataType: MetadataTypes.Injectable
           }),
@@ -176,7 +168,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ContentChild,
             metadataType: MetadataTypes.Pipe
           }),
@@ -195,7 +186,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ContentChildren,
             metadataType: MetadataTypes.Pipe
           }),
@@ -214,7 +204,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.HostBinding,
             metadataType: MetadataTypes.Pipe
           }),
@@ -236,7 +225,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.HostListener,
             metadataType: MetadataTypes.Pipe
           }),
@@ -255,7 +243,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.Input,
             metadataType: MetadataTypes.Pipe
           }),
@@ -274,7 +261,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.Output,
             metadataType: MetadataTypes.Pipe
           }),
@@ -293,7 +279,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ViewChild,
             metadataType: MetadataTypes.Pipe
           }),
@@ -312,7 +297,6 @@ describe(ruleName, () => {
         `;
         assertAnnotated({
           message: getFailureMessage({
-            className: 'Test',
             decoratorName: Decorators.ViewChildren,
             metadataType: MetadataTypes.Pipe
           }),
@@ -337,7 +321,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           decoratorName: Decorators.Input,
           metadataType: MetadataTypes.Pipe
         });
@@ -552,6 +535,12 @@ describe(ruleName, () => {
           assertSuccess(ruleName, source);
         }
       );
+    });
+    describe('A class without name', () => {
+      it('should not broke the linter', () => {
+        let source = 'export default class {}';
+        assertSuccess(ruleName, source);
+      });
     });
   });
 });

--- a/test/contextualLifecycleRule.spec.ts
+++ b/test/contextualLifecycleRule.spec.ts
@@ -18,7 +18,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngAfterContentChecked
         });
@@ -38,7 +37,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngAfterContentInit
         });
@@ -58,7 +56,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngAfterViewChecked
         });
@@ -78,7 +75,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngAfterViewInit
         });
@@ -98,7 +94,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngDoCheck
         });
@@ -118,7 +113,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngOnChanges
         });
@@ -138,7 +132,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Injectable,
           methodName: LifecycleMethods.ngOnInit
         });
@@ -160,7 +153,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngAfterContentChecked
         });
@@ -180,7 +172,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngAfterContentInit
         });
@@ -200,7 +191,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngAfterViewChecked
         });
@@ -220,7 +210,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngAfterViewInit
         });
@@ -240,7 +229,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngDoCheck
         });
@@ -260,7 +248,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngOnChanges
         });
@@ -280,7 +267,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           metadataType: MetadataTypes.Pipe,
           methodName: LifecycleMethods.ngOnInit
         });
@@ -312,7 +298,6 @@ describe(ruleName, () => {
           }
         `;
           const message = getFailureMessage({
-            className: 'Test',
             metadataType: MetadataTypes.Pipe,
             methodName: LifecycleMethods.ngDoCheck
           });
@@ -542,6 +527,12 @@ describe(ruleName, () => {
           assertSuccess(ruleName, source);
         }
       );
+    });
+    describe('A class without name', () => {
+      it('should not broke the linter', () => {
+        let source = 'export default class {}';
+        assertSuccess(ruleName, source);
+      });
     });
   });
 });

--- a/test/contextualLifecycleRule.spec.ts
+++ b/test/contextualLifecycleRule.spec.ts
@@ -17,10 +17,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngAfterContentChecked
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -36,10 +33,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngAfterContentInit
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -55,10 +49,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngAfterViewChecked
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -74,10 +65,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngAfterViewInit
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -93,10 +81,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngDoCheck
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -112,10 +97,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngOnChanges
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -131,10 +113,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Injectable,
-          methodName: LifecycleMethods.ngOnInit
-        });
+        const message = getFailureMessage(MetadataTypes.Injectable);
         assertAnnotated({
           message,
           ruleName,
@@ -152,10 +131,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngAfterContentChecked
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -171,10 +147,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngAfterContentInit
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -190,10 +163,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngAfterViewChecked
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -209,10 +179,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngAfterViewInit
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -228,10 +195,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngDoCheck
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -247,10 +211,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngOnChanges
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -266,10 +227,7 @@ describe(ruleName, () => {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           }
         `;
-        const message = getFailureMessage({
-          metadataType: MetadataTypes.Pipe,
-          methodName: LifecycleMethods.ngOnInit
-        });
+        const message = getFailureMessage(MetadataTypes.Pipe);
         assertAnnotated({
           message,
           ruleName,
@@ -297,10 +255,7 @@ describe(ruleName, () => {
             }
           }
         `;
-          const message = getFailureMessage({
-            metadataType: MetadataTypes.Pipe,
-            methodName: LifecycleMethods.ngDoCheck
-          });
+          const message = getFailureMessage(MetadataTypes.Pipe);
           assertAnnotated({
             message,
             ruleName,

--- a/test/directiveClassSuffix.spec.ts
+++ b/test/directiveClassSuffix.spec.ts
@@ -12,7 +12,7 @@ describe('directive-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-class-suffix',
-        message: 'The name of the class Test should end with the suffix Directive (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a directive should end with the suffix Directive (https://angular.io/styleguide#style-02-03)',
         source
       });
     });
@@ -28,8 +28,7 @@ describe('directive-class-suffix', () => {
       assertAnnotated({
         ruleName: 'directive-class-suffix',
         message:
-          'The name of the class Test should end with the suffix ' +
-          'Directive, Page, Validator (https://angular.io/styleguide#style-02-03)',
+          'The name of a directive should end with the suffix ' + 'Directive, Page, Validator (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Directive', 'Page', 'Validator']
       });
@@ -142,7 +141,7 @@ describe('directive-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-class-suffix',
-        message: 'The name of the class TestPage should end with the suffix Directive (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a directive should end with the suffix Directive (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Directive']
       });
@@ -158,10 +157,16 @@ describe('directive-class-suffix', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-class-suffix',
-        message: 'The name of the class TestDirective should end with the suffix Page (https://angular.io/styleguide#style-02-03)',
+        message: 'The name of a directive should end with the suffix Page (https://angular.io/styleguide#style-02-03)',
         source,
         options: ['Page']
       });
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('directive-class-suffix', source);
     });
   });
 });

--- a/test/directiveSelectorRule.spec.ts
+++ b/test/directiveSelectorRule.spec.ts
@@ -12,7 +12,7 @@ describe('directive-selector-name', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should be named camelCase (https://angular.io/styleguide#style-02-06)',
+        message: 'The selector of a directive should be named camelCase (https://angular.io/styleguide#style-02-06)',
         source,
         options: ['attribute', 'sg', 'camelCase']
       });
@@ -54,7 +54,7 @@ describe('directive-selector-name', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should be named camelCase (https://angular.io/styleguide#style-02-06)',
+        message: 'The selector of a directive should be named camelCase (https://angular.io/styleguide#style-02-06)',
         source,
         options: ['attribute', 'sg', 'camelCase']
       });
@@ -74,7 +74,7 @@ describe('directive-selector-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should have prefix "sg" (https://angular.io/styleguide#style-02-08)',
+        message: 'The selector of a directive should have prefix "sg" (https://angular.io/styleguide#style-02-08)',
         source,
         options: ['attribute', 'sg', 'camelCase']
       });
@@ -90,7 +90,7 @@ describe('directive-selector-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should have prefix "fo" (https://angular.io/styleguide#style-02-08)',
+        message: 'The selector of a directive should have prefix "fo" (https://angular.io/styleguide#style-02-08)',
         source,
         options: ['attribute', 'fo', 'camelCase']
       });
@@ -107,8 +107,7 @@ describe('directive-selector-prefix', () => {
       assertAnnotated({
         ruleName: 'directive-selector',
         message:
-          'The selector of the directive "Test" should have one of the prefixes "sg, ng, mg"' +
-          ' (https://angular.io/styleguide#style-02-08)',
+          'The selector of a directive should have one of the prefixes "sg, ng, mg"' + ' (https://angular.io/styleguide#style-02-08)',
         source,
         options: ['attribute', ['sg', 'ng', 'mg'], 'camelCase']
       });
@@ -125,8 +124,7 @@ describe('directive-selector-prefix', () => {
       assertAnnotated({
         ruleName: 'directive-selector',
         message:
-          'The selector of the directive "Test" should have one of the prefixes "sg, ng, mg"' +
-          ' (https://angular.io/styleguide#style-02-08)',
+          'The selector of a directive should have one of the prefixes "sg, ng, mg"' + ' (https://angular.io/styleguide#style-02-08)',
         source,
         options: ['attribute', ['sg', 'ng', 'mg'], 'camelCase']
       });
@@ -198,7 +196,7 @@ describe('directive-selector-type', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should be used as attribute (https://angular.io/styleguide#style-02-06)',
+        message: 'The selector of a directive should be used as attribute (https://angular.io/styleguide#style-02-06)',
         source,
         options: ['attribute', 'sg', 'camelCase']
       });
@@ -216,7 +214,7 @@ describe('directive-selector-type', () => {
       `;
       assertAnnotated({
         ruleName: 'directive-selector',
-        message: 'The selector of the directive "Test" should be used as attribute (https://angular.io/styleguide#style-02-06)',
+        message: 'The selector of a directive should be used as attribute (https://angular.io/styleguide#style-02-06)',
         source,
         options: ['attribute', 'sg', 'camelCase']
       });
@@ -268,6 +266,12 @@ describe('directive-selector-type', () => {
         class Test {}
       `;
       assertSuccess('directive-selector', source, ['attribute', 'ng', 'camelCase']);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('directive-selector', source, ['attribute', 'sg', 'camelCase']);
     });
   });
 });

--- a/test/importDestructuringSpacingRule.spec.ts
+++ b/test/importDestructuringSpacingRule.spec.ts
@@ -193,4 +193,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noAttributeParameterDecoratorRule.spec.ts
+++ b/test/noAttributeParameterDecoratorRule.spec.ts
@@ -29,7 +29,7 @@ describe('no-attribute-parameter-decorator', () => {
       assertAnnotated({
         ruleName: 'no-attribute-parameter-decorator',
         message:
-          'In the constructor of class "ButtonComponent", the parameter "label" uses the @Attribute decorator, ' +
+          'In the constructor of a directive, the parameter "label" uses the @Attribute decorator, ' +
           'which is considered as a bad practice. Please, consider construction of type "@Input() label: string"',
         source
       });
@@ -47,7 +47,7 @@ describe('no-attribute-parameter-decorator', () => {
       assertAnnotated({
         ruleName: 'no-attribute-parameter-decorator',
         message:
-          'In the constructor of class "SampleTestCase", the parameter "label" uses the @Attribute decorator, ' +
+          'In the constructor of a directive, the parameter "label" uses the @Attribute decorator, ' +
           'which is considered as a bad practice. Please, consider construction of type "@Input() label: string"',
         source
       });
@@ -72,6 +72,12 @@ describe('no-attribute-parameter-decorator', () => {
           };
         }
       `;
+      assertSuccess('no-attribute-parameter-decorator', source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess('no-attribute-parameter-decorator', source);
     });
   });

--- a/test/noConflictingLifecycleRule.spec.ts
+++ b/test/noConflictingLifecycleRule.spec.ts
@@ -1,4 +1,4 @@
-import { getFailureMessage, Rule } from '../src/noConflictingLifecycleRule';
+import { Rule } from '../src/noConflictingLifecycleRule';
 import { assertFailures, assertSuccess, IExpectedFailure } from './testHelper';
 
 const {
@@ -20,19 +20,13 @@ const failures: IExpectedFailure = {
 const interfaceFailures: IExpectedFailure[] = [
   {
     ...failures,
-    message: getFailureMessage({
-      className: 'Test',
-      message: FAILURE_STRING_INTERFACE_HOOK
-    })
+    message: FAILURE_STRING_INTERFACE_HOOK
   }
 ];
 const methodFailures: IExpectedFailure[] = [
   {
     ...failures,
-    message: getFailureMessage({
-      className: 'Test',
-      message: FAILURE_STRING_METHOD_HOOK
-    })
+    message: FAILURE_STRING_METHOD_HOOK
   }
 ];
 
@@ -117,6 +111,12 @@ describe(ruleName, () => {
           ngOnChanges() {}
         }
       `;
+      assertSuccess(ruleName, source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess(ruleName, source);
     });
   });

--- a/test/noForwardRefRule.spec.ts
+++ b/test/noForwardRefRule.spec.ts
@@ -1,4 +1,4 @@
-import { getFailureMessage, Rule } from '../src/noForwardRefRule';
+import { Rule } from '../src/noForwardRefRule';
 import { assertAnnotated, assertSuccess } from './testHelper';
 
 const {
@@ -22,12 +22,8 @@ describe(ruleName, () => {
           }
           export class TestService {}
         `;
-        const message = getFailureMessage({
-          className: 'Test',
-          message: FAILURE_STRING_CLASS
-        });
         assertAnnotated({
-          message,
+          message: FAILURE_STRING_CLASS,
           ruleName,
           source
         });
@@ -48,12 +44,8 @@ describe(ruleName, () => {
           })
           export class TagsValueAccessor {}
         `;
-        const message = getFailureMessage({
-          className: 'TagsValueAccessor',
-          message: FAILURE_STRING_CLASS
-        });
         assertAnnotated({
-          message,
+          message: FAILURE_STRING_CLASS,
           ruleName,
           source
         });
@@ -75,12 +67,8 @@ describe(ruleName, () => {
           })
           export class TagsValueAccessor {}
         `;
-        const message = getFailureMessage({
-          className: 'TAGS_VALUE_ACCESSOR',
-          message: FAILURE_STRING_VARIABLE
-        });
         assertAnnotated({
-          message,
+          message: FAILURE_STRING_VARIABLE,
           ruleName,
           source
         });
@@ -103,6 +91,12 @@ describe(ruleName, () => {
           test() {}
         }
       `;
+      assertSuccess(ruleName, source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess(ruleName, source);
     });
   });

--- a/test/noHostMetadataPropertyRule.spec.ts
+++ b/test/noHostMetadataPropertyRule.spec.ts
@@ -73,4 +73,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noInputPrefixRule.spec.ts
+++ b/test/noInputPrefixRule.spec.ts
@@ -119,4 +119,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source, blacklistedPrefixes);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noInputRenameRule.spec.ts
+++ b/test/noInputRenameRule.spec.ts
@@ -19,7 +19,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestComponent', 'label'),
+          message: getFailureMessage('label'),
           ruleName,
           source
         });
@@ -36,7 +36,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestComponent', 'label'),
+          message: getFailureMessage('label'),
           ruleName,
           source
         });
@@ -55,7 +55,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'label'),
+          message: getFailureMessage('label'),
           ruleName,
           source
         });
@@ -72,7 +72,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'label'),
+          message: getFailureMessage('label'),
           ruleName,
           source
         });
@@ -89,7 +89,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'label'),
+          message: getFailureMessage('label'),
           ruleName,
           source
         });
@@ -106,7 +106,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'ariaBusy'),
+          message: getFailureMessage('ariaBusy'),
           ruleName,
           source
         });
@@ -123,7 +123,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'colors'),
+          message: getFailureMessage('colors'),
           ruleName,
           source
         });
@@ -140,7 +140,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('TestDirective', 'color'),
+          message: getFailureMessage('color'),
           ruleName,
           source
         });
@@ -233,6 +233,12 @@ describe(ruleName, () => {
         `;
         assertSuccess(ruleName, source);
       });
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
     });
   });
 });

--- a/test/noInputRenameRule.spec.ts
+++ b/test/noInputRenameRule.spec.ts
@@ -19,7 +19,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('label'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -36,7 +36,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('label'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -55,7 +55,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('label'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -72,7 +72,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('label'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -89,7 +89,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('label'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -106,7 +106,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('ariaBusy'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -123,7 +123,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('colors'),
+          message: getFailureMessage(),
           ruleName,
           source
         });
@@ -140,7 +140,7 @@ describe(ruleName, () => {
           }
         `;
         assertAnnotated({
-          message: getFailureMessage('color'),
+          message: getFailureMessage(),
           ruleName,
           source
         });

--- a/test/noInputsMetadataPropertyRule.spec.ts
+++ b/test/noInputsMetadataPropertyRule.spec.ts
@@ -69,4 +69,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noLifecycleCallRule.spec.ts
+++ b/test/noLifecycleCallRule.spec.ts
@@ -563,4 +563,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noOutputNativeRule.spec.ts
+++ b/test/noOutputNativeRule.spec.ts
@@ -17,7 +17,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           propertyName: 'change'
         });
         assertAnnotated({
@@ -36,7 +35,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           propertyName: '_change'
         });
         assertAnnotated({
@@ -57,7 +55,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           propertyName: 'change'
         });
         assertAnnotated({
@@ -76,7 +73,6 @@ describe(ruleName, () => {
           }
         `;
         const message = getFailureMessage({
-          className: 'Test',
           propertyName: '_change'
         });
         assertAnnotated({
@@ -131,6 +127,12 @@ describe(ruleName, () => {
         `;
         assertSuccess(ruleName, source);
       });
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
     });
   });
 });

--- a/test/noOutputOnPrefixRule.spec.ts
+++ b/test/noOutputOnPrefixRule.spec.ts
@@ -12,7 +12,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'In the class "ButtonComponent", the output property "onChange" should not be prefixed with on',
+        message: 'The output property "onChange" should not be prefixed with on',
         source
       });
     });
@@ -27,7 +27,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'In the class "ButtonDirective", the output property "onChange" should not be prefixed with on',
+        message: 'The output property "onChange" should not be prefixed with on',
         source
       });
     });
@@ -42,7 +42,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'In the class "ButtonDirective", the output property "on" should not be prefixed with on',
+        message: 'The output property "on" should not be prefixed with on',
         source
       });
     });
@@ -76,6 +76,12 @@ describe('no-output-on-prefix', () => {
           @Output() selectionChanged = new EventEmitter<any>();
         }
       `;
+      assertSuccess('no-output-on-prefix', source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess('no-output-on-prefix', source);
     });
   });

--- a/test/noOutputOnPrefixRule.spec.ts
+++ b/test/noOutputOnPrefixRule.spec.ts
@@ -12,7 +12,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'The output property "onChange" should not be prefixed with on',
+        message: 'Output property should not be prefixed with on',
         source
       });
     });
@@ -27,7 +27,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'The output property "onChange" should not be prefixed with on',
+        message: 'Output property should not be prefixed with on',
         source
       });
     });
@@ -42,7 +42,7 @@ describe('no-output-on-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'no-output-on-prefix',
-        message: 'The output property "on" should not be prefixed with on',
+        message: 'Output property should not be prefixed with on',
         source
       });
     });

--- a/test/noOutputRenameRule.spec.ts
+++ b/test/noOutputRenameRule.spec.ts
@@ -1,8 +1,9 @@
-import { getFailureMessage, Rule } from '../src/noOutputRenameRule';
+import { Rule } from '../src/noOutputRenameRule';
 import { assertAnnotated, assertSuccess } from './testHelper';
 
 const {
-  metadata: { ruleName }
+  metadata: { ruleName },
+  FAILURE_STRING
 } = Rule;
 
 describe(ruleName, () => {
@@ -18,7 +19,7 @@ describe(ruleName, () => {
         }
       `;
       assertAnnotated({
-        message: getFailureMessage(),
+        message: FAILURE_STRING,
         ruleName,
         source
       });
@@ -34,7 +35,7 @@ describe(ruleName, () => {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `;
-      assertAnnotated({ message: getFailureMessage(), ruleName, source });
+      assertAnnotated({ message: FAILURE_STRING, ruleName, source });
     });
 
     it("should fail when the directive's selector matches exactly both property name and the alias", () => {
@@ -47,7 +48,7 @@ describe(ruleName, () => {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `;
-      assertAnnotated({ message: getFailureMessage(), ruleName, source });
+      assertAnnotated({ message: FAILURE_STRING, ruleName, source });
     });
   });
 
@@ -73,6 +74,12 @@ describe(ruleName, () => {
             @Output('foo') bar = new EventEmitter<void>();
           }
         `;
+      assertSuccess(ruleName, source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess(ruleName, source);
     });
   });

--- a/test/noOutputsPropertyMetadataRule.spec.ts
+++ b/test/noOutputsPropertyMetadataRule.spec.ts
@@ -69,4 +69,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noPipeImpureRule.spec.ts
+++ b/test/noPipeImpureRule.spec.ts
@@ -1,8 +1,9 @@
-import { getFailureMessage, Rule } from '../src/noPipeImpureRule';
+import { Rule } from '../src/noPipeImpureRule';
 import { assertAnnotated, assertSuccess } from './testHelper';
 
 const {
-  metadata: { ruleName }
+  metadata: { ruleName },
+  FAILURE_STRING
 } = Rule;
 
 describe(ruleName, () => {
@@ -16,11 +17,8 @@ describe(ruleName, () => {
         })
         class Test {}
       `;
-      const message = getFailureMessage({
-        className: 'Test'
-      });
       assertAnnotated({
-        message,
+        message: FAILURE_STRING,
         ruleName,
         source
       });
@@ -46,6 +44,12 @@ describe(ruleName, () => {
         })
         class Test {}
       `;
+      assertSuccess(ruleName, source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
       assertSuccess(ruleName, source);
     });
   });

--- a/test/noQueriesMetadataPropertyRule.spec.ts
+++ b/test/noQueriesMetadataPropertyRule.spec.ts
@@ -75,4 +75,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/noUnusedCssRule.spec.ts
+++ b/test/noUnusedCssRule.spec.ts
@@ -967,4 +967,10 @@ describe('no-unused-css', () => {
       assertSuccess('no-unused-css', source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('no-unused-css', source);
+    });
+  });
 });

--- a/test/pipePrefixRule.spec.ts
+++ b/test/pipePrefixRule.spec.ts
@@ -12,7 +12,7 @@ describe('pipe-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'pipe-prefix',
-        message: 'The name of a Pipe decorator should start with prefix ng, however its value is "foo-bar"',
+        message: 'The name of a Pipe decorator should start with prefix ng',
         source,
         options: ['ng']
       });
@@ -28,7 +28,7 @@ describe('pipe-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'pipe-prefix',
-        message: 'The name of a Pipe decorator should start' + ' with prefix ng,mg,sg, however its value is "foo-bar"',
+        message: 'The name of a Pipe decorator should start' + ' with prefix ng,mg,sg',
         source,
         options: ['ng', 'mg', 'sg']
       });

--- a/test/pipePrefixRule.spec.ts
+++ b/test/pipePrefixRule.spec.ts
@@ -12,7 +12,7 @@ describe('pipe-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'pipe-prefix',
-        message: 'The name of the Pipe decorator of class Test should start with prefix ng, however its value is "foo-bar"',
+        message: 'The name of a Pipe decorator should start with prefix ng, however its value is "foo-bar"',
         source,
         options: ['ng']
       });
@@ -28,7 +28,7 @@ describe('pipe-prefix', () => {
       `;
       assertAnnotated({
         ruleName: 'pipe-prefix',
-        message: 'The name of the Pipe decorator of class Test should start' + ' with prefix ng,mg,sg, however its value is "foo-bar"',
+        message: 'The name of a Pipe decorator should start' + ' with prefix ng,mg,sg, however its value is "foo-bar"',
         source,
         options: ['ng', 'mg', 'sg']
       });
@@ -99,6 +99,12 @@ describe('pipe-prefix', () => {
         class Test {}
       `;
       assertSuccess('pipe-prefix', source, ['ng']);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('pipe-prefix', source);
     });
   });
 });

--- a/test/preferInlineDecoratorRule.spec.ts
+++ b/test/preferInlineDecoratorRule.spec.ts
@@ -170,6 +170,12 @@ describe(ruleName, () => {
       });
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 
   describe('replacements', () => {
     it('should fail if a property is not on the same line as its decorator', () => {

--- a/test/preferOnPushComponentChangeDetectionRule.spec.ts
+++ b/test/preferOnPushComponentChangeDetectionRule.spec.ts
@@ -51,4 +51,11 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/preferOutputReadonlyRule.spec.ts
+++ b/test/preferOutputReadonlyRule.spec.ts
@@ -29,4 +29,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/relativeUrlPrefixRule.spec.ts
+++ b/test/relativeUrlPrefixRule.spec.ts
@@ -28,6 +28,12 @@ describe(ruleName, () => {
         assertSuccess(ruleName, source);
       });
     });
+    describe('A class without name', () => {
+      it('should not broke the linter', () => {
+        let source = 'export default class {}';
+        assertSuccess(ruleName, source);
+      });
+    });
 
     describe('failure', () => {
       it("should fail when a relative URL isn't prefixed by ./", () => {

--- a/test/templateAccessibilityAltTextRule.spec.ts
+++ b/test/templateAccessibilityAltTextRule.spec.ts
@@ -136,4 +136,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateAccessibilityLabelForRule.spec.ts
+++ b/test/templateAccessibilityLabelForRule.spec.ts
@@ -124,4 +124,10 @@ describe(ruleName, () => {
       });
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateAccessibilityTabindexNoPositiveRule.spec.ts
+++ b/test/templateAccessibilityTabindexNoPositiveRule.spec.ts
@@ -60,4 +60,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateAccessibilityTableScopeRule.spec.ts
+++ b/test/templateAccessibilityTableScopeRule.spec.ts
@@ -57,4 +57,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateAccessibilityValidAriaRule.spec.ts
+++ b/test/templateAccessibilityValidAriaRule.spec.ts
@@ -56,4 +56,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateBananaInBoxRule.spec.ts
+++ b/test/templateBananaInBoxRule.spec.ts
@@ -180,4 +180,10 @@ describe(ruleName, () => {
       `);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateClickEventsHaveKeyEventsRule.spec.ts
+++ b/test/templateClickEventsHaveKeyEventsRule.spec.ts
@@ -219,4 +219,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateConditionalComplexityRule.spec.ts
+++ b/test/templateConditionalComplexityRule.spec.ts
@@ -134,4 +134,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source, [5]);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateCyclomaticComplexityRule.spec.ts
+++ b/test/templateCyclomaticComplexityRule.spec.ts
@@ -120,4 +120,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source, [7]);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateI18nRule.spec.ts
+++ b/test/templateI18nRule.spec.ts
@@ -400,4 +400,10 @@ describe(ruleName, () => {
       });
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateMouseEventsHaveKeyEventsRule.spec.ts
+++ b/test/templateMouseEventsHaveKeyEventsRule.spec.ts
@@ -57,4 +57,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateNoAnyRule.spec.ts
+++ b/test/templateNoAnyRule.spec.ts
@@ -199,4 +199,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateNoAutofocusRule.spec.ts
+++ b/test/templateNoAutofocusRule.spec.ts
@@ -59,4 +59,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateNoCallExpressionRule.spec.ts
+++ b/test/templateNoCallExpressionRule.spec.ts
@@ -85,4 +85,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateNoDistractingElementsRule.spec.ts
+++ b/test/templateNoDistractingElementsRule.spec.ts
@@ -55,4 +55,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateNoNegatedAsyncRule.spec.ts
+++ b/test/templateNoNegatedAsyncRule.spec.ts
@@ -179,4 +179,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/templateUseTrackByFunctionRule.spec.ts
+++ b/test/templateUseTrackByFunctionRule.spec.ts
@@ -214,4 +214,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/useComponentSelectorRule.spec.ts
+++ b/test/useComponentSelectorRule.spec.ts
@@ -13,9 +13,7 @@ describe(ruleName, () => {
         ~~~~~~~~~~~~
         class Test {}
       `;
-      const message = getFailureMessage({
-        className: 'Test'
-      });
+      const message = getFailureMessage();
       assertAnnotated({
         message,
         ruleName,
@@ -32,9 +30,7 @@ describe(ruleName, () => {
         ~~
         class Test {}
       `;
-      const message = getFailureMessage({
-        className: 'Test'
-      });
+      const message = getFailureMessage();
       assertAnnotated({
         message,
         ruleName,
@@ -51,9 +47,7 @@ describe(ruleName, () => {
         ~~
         class Test {}
       `;
-      const message = getFailureMessage({
-        className: 'Test'
-      });
+      const message = getFailureMessage();
       assertAnnotated({
         message,
         ruleName,
@@ -70,9 +64,7 @@ describe(ruleName, () => {
         ~~
         class Test {}
       `;
-      const message = getFailureMessage({
-        className: 'Test'
-      });
+      const message = getFailureMessage();
       assertAnnotated({
         message,
         ruleName,

--- a/test/useComponentSelectorRule.spec.ts
+++ b/test/useComponentSelectorRule.spec.ts
@@ -92,4 +92,15 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/useComponentViewEncapsulationRule.spec.ts
+++ b/test/useComponentViewEncapsulationRule.spec.ts
@@ -79,4 +79,10 @@ describe(ruleName, () => {
       assertSuccess(ruleName, source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      const source = 'export default class {}';
+      assertSuccess(ruleName, source);
+    });
+  });
 });

--- a/test/useLifecycleInterfaceRule.spec.ts
+++ b/test/useLifecycleInterfaceRule.spec.ts
@@ -17,7 +17,6 @@ describe(ruleName, () => {
         }
       `;
       const message = getFailureMessage({
-        className: 'Test',
         interfaceName: LifecycleInterfaces.OnInit,
         methodName: LifecycleMethods.ngOnInit
       });
@@ -39,7 +38,6 @@ describe(ruleName, () => {
         }
       `;
       const message = getFailureMessage({
-        className: 'Test',
         interfaceName: LifecycleInterfaces.OnDestroy,
         methodName: LifecycleMethods.ngOnDestroy
       });
@@ -65,7 +63,6 @@ describe(ruleName, () => {
             line: 2
           },
           message: getFailureMessage({
-            className: 'Test',
             interfaceName: LifecycleInterfaces.OnInit,
             methodName: LifecycleMethods.ngOnInit
           }),
@@ -80,7 +77,6 @@ describe(ruleName, () => {
             line: 4
           },
           message: getFailureMessage({
-            className: 'Test',
             interfaceName: LifecycleInterfaces.OnDestroy,
             methodName: LifecycleMethods.ngOnDestroy
           }),
@@ -103,7 +99,6 @@ describe(ruleName, () => {
         }
       `;
       const message = getFailureMessage({
-        className: 'Test',
         interfaceName: LifecycleInterfaces.OnDestroy,
         methodName: LifecycleMethods.ngOnDestroy
       });
@@ -159,6 +154,12 @@ describe(ruleName, () => {
       const source = `
         class Test {}
       `;
+      assertSuccess(ruleName, source);
+    });
+  });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      const source = 'export default class {}';
       assertSuccess(ruleName, source);
     });
   });

--- a/test/usePipeDecoratorRule.spec.ts
+++ b/test/usePipeDecoratorRule.spec.ts
@@ -63,4 +63,10 @@ describe('use-pipe-decorator', () => {
       assertSuccess('use-pipe-decorator', source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('use-pipe-decorator', source);
+    });
+  });
 });

--- a/test/usePipeDecoratorRule.spec.ts
+++ b/test/usePipeDecoratorRule.spec.ts
@@ -12,7 +12,7 @@ describe('use-pipe-decorator', () => {
       `;
       assertAnnotated({
         ruleName: 'use-pipe-decorator',
-        message: 'The NewPipe class implements the PipeTransform interface, so it should use the @Pipe decorator',
+        message: 'A class which implements the PipeTransform interface should use the @Pipe decorator',
         source
       });
     });
@@ -26,7 +26,7 @@ describe('use-pipe-decorator', () => {
       `;
       assertAnnotated({
         ruleName: 'use-pipe-decorator',
-        message: 'The Test class implements the PipeTransform interface, so it should use the @Pipe decorator',
+        message: 'A class which implements the PipeTransform interface should use the @Pipe decorator',
         source
       });
     });
@@ -41,7 +41,7 @@ describe('use-pipe-decorator', () => {
       `;
       assertAnnotated({
         ruleName: 'use-pipe-decorator',
-        message: 'The Test class implements the PipeTransform interface, so it should use the @Pipe decorator',
+        message: 'A class which implements the PipeTransform interface should use the @Pipe decorator',
         source
       });
     });

--- a/test/usePipeTransformInterfaceRule.spec.ts
+++ b/test/usePipeTransformInterfaceRule.spec.ts
@@ -13,7 +13,7 @@ describe('use-pipe-transform-interface', () => {
       `;
       assertAnnotated({
         ruleName: 'use-pipe-transform-interface',
-        message: 'The NewPipe class has the Pipe decorator, so it should implement the PipeTransform interface',
+        message: 'A class which has the Pipe decorator should implement the PipeTransform interface',
         source
       });
     });

--- a/test/usePipeTransformInterfaceRule.spec.ts
+++ b/test/usePipeTransformInterfaceRule.spec.ts
@@ -56,4 +56,10 @@ describe('use-pipe-transform-interface', () => {
       assertSuccess('use-pipe-transform-interface', source);
     });
   });
+  describe('A class without name', () => {
+    it('should not broke the linter', () => {
+      let source = 'export default class {}';
+      assertSuccess('use-pipe-transform-interface', source);
+    });
+  });
 });


### PR DESCRIPTION
- improve NgWalker 
- Remove class name from error message
- Prevent an error when a class has no name.

closes #778 