### PR TITLE
refactor: improve ngWalker by preventing an error when a class has no name

### DIFF
--- a/src/angular/metadata.ts
+++ b/src/angular/metadata.ts
@@ -25,21 +25,17 @@ export interface TemplateMetadata extends PropertyMetadata {
 }
 
 export class DirectiveMetadata {
-  constructor(
-    public readonly controller: ts.ClassDeclaration,
-    public readonly decorator: ts.Decorator,
-    public readonly selector?: string
-  ) {}
+  constructor(readonly controller: ts.ClassDeclaration, readonly decorator: ts.Decorator, readonly selector?: string) {}
 }
 
 export class ComponentMetadata extends DirectiveMetadata {
   constructor(
-    public readonly controller: ts.ClassDeclaration,
-    public readonly decorator: ts.Decorator,
-    public readonly selector?: string,
-    public readonly animations?: (AnimationMetadata | undefined)[],
-    public readonly styles?: (StyleMetadata | undefined)[],
-    public readonly template?: TemplateMetadata
+    readonly controller: ts.ClassDeclaration,
+    readonly decorator: ts.Decorator,
+    readonly selector?: string,
+    readonly animations?: (AnimationMetadata | undefined)[],
+    readonly styles?: (StyleMetadata | undefined)[],
+    readonly template?: TemplateMetadata
   ) {
     super(controller, decorator, selector);
   }
@@ -47,17 +43,17 @@ export class ComponentMetadata extends DirectiveMetadata {
 
 export class PipeMetadata {
   constructor(
-    public readonly controller: ts.ClassDeclaration,
-    public readonly decorator: ts.Decorator,
-    public readonly name?: string,
-    public readonly pure?: string
+    readonly controller: ts.ClassDeclaration,
+    readonly decorator: ts.Decorator,
+    readonly name?: string,
+    readonly pure?: ts.BooleanLiteral
   ) {}
 }
 
 export class ModuleMetadata {
-  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator) {}
+  constructor(readonly controller: ts.ClassDeclaration, readonly decorator: ts.Decorator) {}
 }
 
 export class InjectableMetadata {
-  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator) {}
+  constructor(readonly controller: ts.ClassDeclaration, readonly decorator: ts.Decorator) {}
 }

--- a/src/angular/metadata.ts
+++ b/src/angular/metadata.ts
@@ -44,3 +44,20 @@ export class ComponentMetadata extends DirectiveMetadata {
     super(controller, decorator, selector);
   }
 }
+
+export class PipeMetadata {
+  constructor(
+    public readonly controller: ts.ClassDeclaration,
+    public readonly decorator: ts.Decorator,
+    public readonly name?: string,
+    public readonly pure?: string
+  ) {}
+}
+
+export class ModuleMetadata {
+  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator) {}
+}
+
+export class InjectableMetadata {
+  constructor(public readonly controller: ts.ClassDeclaration, public readonly decorator: ts.Decorator) {}
+}

--- a/src/angular/metadataReader.ts
+++ b/src/angular/metadataReader.ts
@@ -97,9 +97,9 @@ export class MetadataReader {
     const name = nameExpression && isStringLiteralLike(nameExpression) ? nameExpression.text : undefined;
 
     const pureExpression = getDecoratorPropertyInitializer(dec, 'pure');
-    const isBoolean = pureExpression && isBooleanLiteralLike(pureExpression);
+    const pure = pureExpression && isBooleanLiteralLike(pureExpression) ? pureExpression : undefined;
 
-    return new PipeMetadata(d, dec, name, isBoolean ? (pureExpression as ts.BooleanLiteral) : undefined);
+    return new PipeMetadata(d, dec, name, pure);
   }
 
   protected readModuleMetadata(d: ts.ClassDeclaration, dec: ts.Decorator): DirectiveMetadata {

--- a/src/angular/ngWalker.ts
+++ b/src/angular/ngWalker.ts
@@ -2,9 +2,9 @@ import * as compiler from '@angular/compiler';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import { logger } from '../util/logger';
-import { getDecoratorName, maybeNodeArray } from '../util/utils';
+import { getClassName, getDecoratorName, maybeNodeArray } from '../util/utils';
 import { Config } from './config';
-import { ComponentMetadata, DirectiveMetadata, StyleMetadata } from './metadata';
+import { ComponentMetadata, DirectiveMetadata, InjectableMetadata, ModuleMetadata, PipeMetadata, StyleMetadata } from './metadata';
 import { MetadataReader } from './metadataReader';
 import { ngWalkerFactoryUtils } from './ngWalkerFactoryUtils';
 import { BasicCssAstVisitor, CssAstVisitorCtrl } from './styles/basicCssAstVisitor';
@@ -61,11 +61,19 @@ export class NgWalker extends Lint.RuleWalker {
   }
 
   visitClassDeclaration(declaration: ts.ClassDeclaration) {
-    const metadata = this._metadataReader!.read(declaration);
-    if (metadata instanceof ComponentMetadata) {
-      this.visitNgComponent(metadata);
-    } else if (metadata instanceof DirectiveMetadata) {
-      this.visitNgDirective(metadata);
+    if (this.hasClassName(declaration)) {
+      const metadata = this._metadataReader!.read(declaration);
+      if (metadata instanceof ComponentMetadata) {
+        this.visitNgComponent(metadata);
+      } else if (metadata instanceof DirectiveMetadata) {
+        this.visitNgDirective(metadata);
+      } else if (metadata instanceof PipeMetadata) {
+        this.visitNgPipe(metadata);
+      } else if (metadata instanceof ModuleMetadata) {
+        this.visitNgModule(metadata);
+      } else if (metadata instanceof InjectableMetadata) {
+        this.visitNgInjectable(metadata);
+      }
     }
     maybeNodeArray(ts.createNodeArray(declaration.decorators)).forEach(this.visitClassDecorator.bind(this));
     super.visitClassDeclaration(declaration);
@@ -115,22 +123,6 @@ export class NgWalker extends Lint.RuleWalker {
     }
   }
 
-  protected visitClassDecorator(decorator: ts.Decorator) {
-    let name = getDecoratorName(decorator);
-
-    if (name === 'Injectable') {
-      this.visitNgInjectable(decorator.parent as ts.ClassDeclaration, decorator);
-    }
-
-    if (name === 'Pipe') {
-      this.visitNgPipe(decorator.parent as ts.ClassDeclaration, decorator);
-    }
-
-    if (name === 'NgModule') {
-      this.visitNgModule(decorator);
-    }
-  }
-
   protected visitNgComponent(metadata: ComponentMetadata) {
     const { styles = [] } = metadata;
 
@@ -165,13 +157,15 @@ export class NgWalker extends Lint.RuleWalker {
     }
   }
 
-  protected visitNgModule(decorator: ts.Decorator) {}
+  protected visitClassDecorator(decorator: ts.Decorator) {}
+
+  protected visitNgModule(metadata: ModuleMetadata) {}
 
   protected visitNgDirective(metadata: DirectiveMetadata) {}
 
-  protected visitNgPipe(controller: ts.ClassDeclaration, decorator: ts.Decorator) {}
+  protected visitNgPipe(metadata: DirectiveMetadata) {}
 
-  protected visitNgInjectable(classDeclaration: ts.ClassDeclaration, decorator: ts.Decorator) {}
+  protected visitNgInjectable(metadata: InjectableMetadata) {}
 
   protected visitNgInput(property: ts.PropertyDeclaration, input: ts.Decorator, args: string[]) {}
 
@@ -236,5 +230,14 @@ export class NgWalker extends Lint.RuleWalker {
     };
 
     return sf;
+  }
+
+  private hasClassName(node: ts.Decorator | ts.ClassDeclaration) {
+    if (ts.isDecorator(node) && !getClassName(node.parent as ts.ClassDeclaration)) {
+      return false;
+    } else if (ts.isClassDeclaration(node) && !getClassName(node)) {
+      return false;
+    }
+    return true;
   }
 }

--- a/src/angular/ngWalker.ts
+++ b/src/angular/ngWalker.ts
@@ -163,7 +163,7 @@ export class NgWalker extends Lint.RuleWalker {
 
   protected visitNgDirective(metadata: DirectiveMetadata) {}
 
-  protected visitNgPipe(metadata: DirectiveMetadata) {}
+  protected visitNgPipe(metadata: PipeMetadata) {}
 
   protected visitNgInjectable(metadata: InjectableMetadata) {}
 
@@ -233,11 +233,6 @@ export class NgWalker extends Lint.RuleWalker {
   }
 
   private hasClassName(node: ts.Decorator | ts.ClassDeclaration) {
-    if (ts.isDecorator(node) && !getClassName(node.parent as ts.ClassDeclaration)) {
-      return false;
-    } else if (ts.isClassDeclaration(node) && !getClassName(node)) {
-      return false;
-    }
-    return true;
+    return (ts.isDecorator(node) && getClassName(node.parent)) || (ts.isClassDeclaration(node) && getClassName(node));
   }
 }

--- a/src/contextualLifecycleRule.ts
+++ b/src/contextualLifecycleRule.ts
@@ -14,6 +14,7 @@ import {
   MetadataTypeKeys,
   MetadataTypes
 } from './util/utils';
+import { InjectableMetadata, PipeMetadata } from './angular';
 
 interface FailureParameters {
   readonly className: string;
@@ -45,20 +46,18 @@ export class Rule extends AbstractRule {
 }
 
 class ContextualLifecycleWalker extends NgWalker {
-  protected visitNgInjectable(controller: ClassDeclaration, decorator: Decorator): void {
-    this.validateDecorator(controller, decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Injectable);
-    super.visitNgInjectable(controller, decorator);
+  visitNgInjectable(metadata: InjectableMetadata): void {
+    this.validateDecorator(metadata.controller, metadata.decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Injectable);
+    super.visitNgInjectable(metadata);
   }
 
-  protected visitNgPipe(controller: ClassDeclaration, decorator: Decorator): void {
-    this.validateDecorator(controller, decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Pipe);
-    super.visitNgPipe(controller, decorator);
+  visitNgPipe(metadata: PipeMetadata): void {
+    this.validateDecorator(metadata.controller, metadata.decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Pipe);
+    super.visitNgPipe(metadata);
   }
 
   private validateDecorator(controller: ClassDeclaration, decorator: Decorator, allowedMethods: ReadonlySet<LifecycleMethodKeys>): void {
-    const className = getClassName(controller);
-
-    if (!className) return;
+    const className = getClassName(controller)!;
 
     const metadataType = getDecoratorName(decorator);
 

--- a/src/contextualLifecycleRule.ts
+++ b/src/contextualLifecycleRule.ts
@@ -46,24 +46,24 @@ export class Rule extends AbstractRule {
 }
 
 class ContextualLifecycleWalker extends NgWalker {
-  visitNgInjectable(metadata: InjectableMetadata): void {
-    this.validateDecorator(metadata.controller, metadata.decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Injectable);
+  protected visitNgInjectable(metadata: InjectableMetadata): void {
+    this.validateDecorator(metadata, METADATA_TYPE_LIFECYCLE_MAPPER.Injectable);
     super.visitNgInjectable(metadata);
   }
 
-  visitNgPipe(metadata: PipeMetadata): void {
-    this.validateDecorator(metadata.controller, metadata.decorator, METADATA_TYPE_LIFECYCLE_MAPPER.Pipe);
+  protected visitNgPipe(metadata: PipeMetadata): void {
+    this.validateDecorator(metadata, METADATA_TYPE_LIFECYCLE_MAPPER.Pipe);
     super.visitNgPipe(metadata);
   }
 
-  private validateDecorator(controller: ClassDeclaration, decorator: Decorator, allowedMethods: ReadonlySet<LifecycleMethodKeys>): void {
-    const className = getClassName(controller)!;
+  private validateDecorator(metadata: PipeMetadata, allowedMethods: ReadonlySet<LifecycleMethodKeys>): void {
+    const className = getClassName(metadata.controller)!;
 
-    const metadataType = getDecoratorName(decorator);
+    const metadataType = getDecoratorName(metadata.decorator);
 
     if (!metadataType || !isMetadataType(metadataType)) return;
 
-    for (const member of controller.members) {
+    for (const member of metadata.controller.members) {
       const { name: memberName } = member;
 
       if (!memberName) continue;

--- a/src/noOutputRenameRule.ts
+++ b/src/noOutputRenameRule.ts
@@ -29,7 +29,7 @@ export const getFailureMessage = (): string => {
 export class OutputMetadataWalker extends NgWalker {
   private directiveSelectors!: ReadonlySet<DirectiveMetadata['selector']>;
 
-  visitNgDirective(metadata: DirectiveMetadata): void {
+  protected visitNgDirective(metadata: DirectiveMetadata): void {
     this.directiveSelectors = new Set((metadata.selector || '').replace(/[\[\]\s]/g, '').split(','));
     super.visitNgDirective(metadata);
   }

--- a/src/noPipeImpureRule.ts
+++ b/src/noPipeImpureRule.ts
@@ -38,8 +38,7 @@ export class ClassMetadataWalker extends NgWalker {
   }
 
   private validatePipe(metadata: PipeMetadata): void {
-    if (!metadata.pure) return;
-    if (metadata.pure!.kind !== SyntaxKind.FalseKeyword) return;
+    if (!metadata.pure || metadata.pure.kind !== SyntaxKind.FalseKeyword) return;
 
     const className = getClassName(metadata.controller)!;
 

--- a/src/noPipeImpureRule.ts
+++ b/src/noPipeImpureRule.ts
@@ -38,19 +38,13 @@ export class ClassMetadataWalker extends NgWalker {
   }
 
   private validatePipe(metadata: PipeMetadata): void {
-    const pureExpression = getDecoratorPropertyInitializer(metadata.decorator, 'pure');
-
-    if (!pureExpression) return;
-
-    const { parent: parentExpression } = pureExpression;
-    const isNotFalseLiteral = pureExpression.kind !== SyntaxKind.FalseKeyword;
-
-    if (!parentExpression || isNotFalseLiteral) return;
+    if (!metadata.pure) return;
+    if (metadata.pure!.kind !== SyntaxKind.FalseKeyword) return;
 
     const className = getClassName(metadata.controller)!;
 
     const failure = getFailureMessage({ className });
 
-    this.addFailureAtNode(parentExpression, failure);
+    this.addFailureAtNode(metadata.pure, failure);
   }
 }

--- a/src/noPipeImpureRule.ts
+++ b/src/noPipeImpureRule.ts
@@ -4,6 +4,7 @@ import { AbstractRule } from 'tslint/lib/rules';
 import { ClassDeclaration, Decorator, SourceFile, SyntaxKind } from 'typescript';
 import { NgWalker } from './angular/ngWalker';
 import { getClassName, getDecoratorPropertyInitializer } from './util/utils';
+import { PipeMetadata } from './angular';
 
 interface FailureParameters {
   readonly className: string;
@@ -31,13 +32,13 @@ export class Rule extends AbstractRule {
 }
 
 export class ClassMetadataWalker extends NgWalker {
-  protected visitNgPipe(controller: ClassDeclaration, decorator: Decorator): void {
-    this.validatePipe(controller, decorator);
-    super.visitNgPipe(controller, decorator);
+  protected visitNgPipe(metadata: PipeMetadata): void {
+    this.validatePipe(metadata);
+    super.visitNgPipe(metadata);
   }
 
-  private validatePipe(controller: ClassDeclaration, decorator: Decorator): void {
-    const pureExpression = getDecoratorPropertyInitializer(decorator, 'pure');
+  private validatePipe(metadata: PipeMetadata): void {
+    const pureExpression = getDecoratorPropertyInitializer(metadata.decorator, 'pure');
 
     if (!pureExpression) return;
 
@@ -46,9 +47,7 @@ export class ClassMetadataWalker extends NgWalker {
 
     if (!parentExpression || isNotFalseLiteral) return;
 
-    const className = getClassName(controller);
-
-    if (!className) return;
+    const className = getClassName(metadata.controller)!;
 
     const failure = getFailureMessage({ className });
 

--- a/src/pipePrefixRule.ts
+++ b/src/pipePrefixRule.ts
@@ -4,6 +4,7 @@ import * as ts from 'typescript';
 import { NgWalker } from './angular/ngWalker';
 import { SelectorValidator } from './util/selectorValidator';
 import { getDecoratorArgument } from './util/utils';
+import { PipeMetadata } from './angular';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -69,10 +70,10 @@ export class ClassMetadataWalker extends NgWalker {
     super(sourceFile, rule.getOptions());
   }
 
-  protected visitNgPipe(controller: ts.ClassDeclaration, decorator: ts.Decorator) {
-    let className = controller.name!.text;
-    this.validateProperties(className, decorator);
-    super.visitNgPipe(controller, decorator);
+  protected visitNgPipe(metadata: PipeMetadata) {
+    let className = metadata.controller.name!.text;
+    this.validateProperties(className, metadata.decorator);
+    super.visitNgPipe(metadata);
   }
 
   private validateProperties(className: string, pipe: ts.Decorator) {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -19,6 +19,7 @@ import {
   ObjectLiteralExpression,
   SourceFile,
   StringLiteral,
+  BooleanLiteral,
   SyntaxKind
 } from 'typescript';
 import { getDeclaredMethods } from './classDeclarationUtils';
@@ -201,6 +202,9 @@ export const isSameLine = (sourceFile: SourceFile, pos1: number, pos2: number): 
 
 export const isStringLiteralLike = (node: Node): node is StringLiteral | NoSubstitutionTemplateLiteral =>
   isStringLiteral(node) || isNoSubstitutionTemplateLiteral(node);
+
+export const isBooleanLiteralLike = (node: Node): node is BooleanLiteral =>
+  node.kind === SyntaxKind.FalseKeyword || node.kind === SyntaxKind.TrueKeyword;
 
 export const maybeNodeArray = <T extends Node>(nodes: NodeArray<T>): ReadonlyArray<T> => nodes || [];
 

--- a/test/angular/metadataReader.spec.ts
+++ b/test/angular/metadataReader.spec.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 import { Config } from '../../src/angular/config';
 import { DummyFileResolver } from '../../src/angular/fileResolver/dummyFileResolver';
 import { FsFileResolver } from '../../src/angular/fileResolver/fsFileResolver';
-import { ComponentMetadata } from '../../src/angular/metadata';
+import { ComponentMetadata, DirectiveMetadata, PipeMetadata } from '../../src/angular/metadata';
 import { MetadataReader } from '../../src/angular/metadataReader';
 
 import { join, normalize } from 'path';
@@ -25,7 +25,22 @@ describe('metadataReader', () => {
       const reader = new MetadataReader(new DummyFileResolver());
       const ast = getAst(code);
       const metadata = reader.read(last(ast.statements) as ts.ClassDeclaration)!;
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(DirectiveMetadata);
+      expect((metadata as DirectiveMetadata).selector).eq('foo');
+    });
+
+    it('should read name', () => {
+      const code = `
+        @Pipe({
+          name: 'foo'
+        })
+        class Bar {}
+      `;
+      const reader = new MetadataReader(new DummyFileResolver());
+      const ast = getAst(code);
+      const metadata = reader.read(last(ast.statements) as ts.ClassDeclaration)!;
+      expect(metadata).instanceof(PipeMetadata);
+      expect((metadata as PipeMetadata).name).eq('foo');
     });
 
     it('should not fail with empty decorator', () => {
@@ -36,7 +51,8 @@ describe('metadataReader', () => {
       const reader = new MetadataReader(new DummyFileResolver());
       const ast = getAst(code);
       const metadata = reader.read(last(ast.statements) as ts.ClassDeclaration)!;
-      expect(metadata.selector).eq(undefined);
+      expect(metadata).instanceof(DirectiveMetadata);
+      expect((metadata as DirectiveMetadata).selector).eq(undefined);
     });
 
     it('should provide class declaration', () => {
@@ -48,6 +64,7 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
+      expect(metadata).instanceof(DirectiveMetadata);
       expect(metadata.controller).eq(classDeclaration);
     });
   });
@@ -66,8 +83,8 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code).eq('bar');
       expect(m.template!.url).eq(undefined);
@@ -88,8 +105,8 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code).eq('');
       expect(m.template!.url).eq('bar');
@@ -111,8 +128,8 @@ describe('metadataReader', () => {
       const ast = getAst(code);
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code).eq('qux');
       expect(m.template!.url).eq(undefined);
@@ -133,8 +150,8 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code.trim()).eq('<div></div>');
       expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -155,8 +172,8 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/moduleid/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code.trim()).eq('<div></div>');
       expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -187,8 +204,8 @@ describe('metadataReader', () => {
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
         expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        expect(metadata instanceof ComponentMetadata).eq(true);
-        expect(metadata.selector).eq('foo');
+        expect(metadata).instanceof(ComponentMetadata);
+        expect((metadata as ComponentMetadata).selector).eq('foo');
         const m = <ComponentMetadata>metadata;
         expect(m.template!.template.code.trim()).eq('<div></div>');
         expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -223,8 +240,8 @@ describe('metadataReader', () => {
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
         expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        expect(metadata instanceof ComponentMetadata).eq(true);
-        expect(metadata.selector).eq('foo');
+        expect(metadata).instanceof(ComponentMetadata);
+        expect((metadata as ComponentMetadata).selector).eq('foo');
         const m = <ComponentMetadata>metadata;
         expect(m.template!.template.code.trim()).eq('<div></div>');
         expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -259,8 +276,8 @@ describe('metadataReader', () => {
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
         expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        expect(metadata instanceof ComponentMetadata).eq(true);
-        expect(metadata.selector).eq('foo');
+        expect(metadata).instanceof(ComponentMetadata);
+        expect((metadata as ComponentMetadata).selector).eq('foo');
         const m = <ComponentMetadata>metadata;
         expect(m.template!.template.code.trim()).eq('<div></div>');
         expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -300,8 +317,8 @@ describe('metadataReader', () => {
         const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
         expect(invoked).eq(false);
         const metadata = reader.read(classDeclaration)!;
-        expect(metadata instanceof ComponentMetadata).eq(true);
-        expect(metadata.selector).eq('foo');
+        expect(metadata).instanceof(ComponentMetadata);
+        expect((metadata as ComponentMetadata).selector).eq('foo');
         const m = <ComponentMetadata>metadata;
         expect(m.template!.template.code.trim()).eq('<div></div>');
         expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -327,8 +344,8 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/specialsymbols/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code.trim()).eq('<div>`</div>');
       expect(m.template!.url!.endsWith('foo.html')).eq(true);
@@ -350,8 +367,8 @@ describe('metadataReader', () => {
       const ast = getAst(code, __dirname + '/../../test/fixtures/metadataReader/notsupported/foo.ts');
       const classDeclaration = <ts.ClassDeclaration>last(ast.statements);
       const metadata = reader.read(classDeclaration)!;
-      expect(metadata instanceof ComponentMetadata).eq(true);
-      expect(metadata.selector).eq('foo');
+      expect(metadata).instanceof(ComponentMetadata);
+      expect((metadata as ComponentMetadata).selector).eq('foo');
       const m = <ComponentMetadata>metadata;
       expect(m.template!.template.code.trim()).eq('');
       expect(m.template!.url!.endsWith('foo.dust')).eq(true);

--- a/test/angular/ngWalker.spec.ts
+++ b/test/angular/ngWalker.spec.ts
@@ -54,6 +54,47 @@ describe('ngWalker', () => {
     (chai.expect(injSpy).to.have.been as any).called();
   });
 
+  it('should not visit components, directives, pipes, injectables, and modules', () => {
+    let source = `
+      @Component({
+        selector: 'foo',
+        template: 'bar'
+      })
+      export default class {}
+      @Directive({
+        selector: '[baz]'
+      })
+      export default class {}
+      @Pipe({
+        name: 'foo'
+      })
+      export default class {}
+      @NgModule({})
+      export default class {}
+      @Injectable()
+      export default class {}
+    `;
+    let ruleArgs: Lint.IOptions = {
+      ruleName: 'foo',
+      ruleArguments: ['foo'],
+      disabledIntervals: [],
+      ruleSeverity: 'warning'
+    };
+    let sf = ts.createSourceFile('foo', source, ts.ScriptTarget.ES5);
+    let walker = new NgWalker(sf, ruleArgs);
+    let cmpSpy = chaiSpy.on(walker, 'visitNgComponent');
+    let dirSpy = chaiSpy.on(walker, 'visitNgDirective');
+    let pipeSpy = chaiSpy.on(walker, 'visitNgPipe');
+    let modSpy = chaiSpy.on(walker, 'visitNgModule');
+    let injSpy = chaiSpy.on(walker, 'visitNgInjectable');
+    walker.walk(sf);
+    (chai.expect(cmpSpy).to.not.have.been as any).called();
+    (chai.expect(dirSpy).to.not.have.been as any).called();
+    (chai.expect(pipeSpy).to.not.have.been as any).called();
+    (chai.expect(modSpy).to.not.have.been as any).called();
+    (chai.expect(injSpy).to.not.have.been as any).called();
+  });
+
   it('should visit inputs and outputs with args', () => {
     let source = `
       @Component({

--- a/test/noPipeImpureRule.spec.ts
+++ b/test/noPipeImpureRule.spec.ts
@@ -12,7 +12,7 @@ describe(ruleName, () => {
         @Pipe({
           name: 'test',
           pure: false
-          ~~~~~~~~~~~
+                ~~~~~
         })
         class Test {}
       `;


### PR DESCRIPTION
closes #778 