### PR TITLE
refactor: walkers/visitors being exported

### DIFF
--- a/src/componentClassSuffixRule.ts
+++ b/src/componentClassSuffixRule.ts
@@ -1,11 +1,11 @@
 import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
+import { NgWalker } from './angular';
 import { ComponentMetadata } from './angular/metadata';
-import { Maybe, F2 } from './util/function';
+import { F2, Maybe } from './util/function';
 import { Failure } from './walkerFactory/walkerFactory';
 import { all, validateComponent } from './walkerFactory/walkerFn';
-import { NgWalker } from '.';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -51,6 +51,8 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(Rule.walkerBuilder(sourceFile, this.getOptions()));
+    const walker = Rule.walkerBuilder(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }

--- a/src/componentMaxInlineDeclarationsRule.ts
+++ b/src/componentMaxInlineDeclarationsRule.ts
@@ -66,7 +66,9 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = `Exceeds the maximum allowed inline lines for %s. Defined limit: %s / total lines: %s (${STYLE_GUIDE_LINK})`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new MaxInlineDeclarationsWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -81,7 +83,7 @@ export class Rule extends AbstractRule {
   }
 }
 
-export class MaxInlineDeclarationsWalker extends NgWalker {
+class Walker extends NgWalker {
   private readonly animationsLinesLimit = DEFAULT_ANIMATIONS_LIMIT;
   private readonly stylesLinesLimit = DEFAULT_STYLES_LIMIT;
   private readonly templateLinesLimit = DEFAULT_TEMPLATE_LIMIT;

--- a/src/contextualDecoratorRule.ts
+++ b/src/contextualDecoratorRule.ts
@@ -39,11 +39,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'The decorator "%s" is not allowed for class "%s" because it is decorated with "%s"';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new ContextualDecoratorWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-export class ContextualDecoratorWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitMethodDecorator(decorator: Decorator): void {
     this.validateDecorator(decorator);
     super.visitMethodDecorator(decorator);

--- a/src/contextualLifecycleRule.ts
+++ b/src/contextualLifecycleRule.ts
@@ -1,7 +1,8 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure } from 'tslint/lib';
 import { AbstractRule } from 'tslint/lib/rules';
-import { ClassDeclaration, Decorator, SourceFile } from 'typescript';
+import { SourceFile } from 'typescript';
+import { InjectableMetadata, ModuleMetadata, PipeMetadata } from './angular';
 import { NgWalker } from './angular/ngWalker';
 import {
   getClassName,
@@ -14,7 +15,6 @@ import {
   MetadataTypeKeys,
   MetadataTypes
 } from './util/utils';
-import { InjectableMetadata, ModuleMetadata, PipeMetadata } from './angular';
 
 interface FailureParameters {
   readonly className: string;
@@ -41,11 +41,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'The method "%s" is not allowed for class "%s" because it is decorated with "%s"';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new ContextualLifecycleWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class ContextualLifecycleWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgInjectable(metadata: InjectableMetadata): void {
     this.validateDecorator(metadata, METADATA_TYPE_LIFECYCLE_MAPPER.Injectable);
     super.visitNgInjectable(metadata);

--- a/src/directiveClassSuffixRule.ts
+++ b/src/directiveClassSuffixRule.ts
@@ -1,10 +1,9 @@
 import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
+import { DirectiveMetadata } from './angular/metadata';
 import { NgWalker } from './angular/ngWalker';
 import { getSymbolName } from './util/utils';
-
-import { DirectiveMetadata } from './angular/metadata';
 
 const ValidatorSuffix = 'Validator';
 
@@ -34,11 +33,13 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-export class ClassMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgDirective(metadata: DirectiveMetadata) {
     const name = metadata.controller.name!;
     const className = name.text;

--- a/src/noInputPrefixRule.ts
+++ b/src/noInputPrefixRule.ts
@@ -1,7 +1,6 @@
 import { sprintf } from 'sprintf-js';
 import { IOptions, IRuleMetadata, RuleFailure, Rules, Utils } from 'tslint/lib';
 import { Decorator, PropertyDeclaration, SourceFile } from 'typescript';
-
 import { NgWalker } from './angular/ngWalker';
 
 export class Rule extends Rules.AbstractRule {
@@ -30,7 +29,9 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = '@Inputs should not be prefixed by %s';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new NoInputPrefixWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -62,7 +63,7 @@ export const getFailureMessage = (prefixes: string[]): string => {
   return sprintf(Rule.FAILURE_STRING, getReadablePrefixes(prefixes));
 };
 
-class NoInputPrefixWalker extends NgWalker {
+class Walker extends NgWalker {
   private readonly blacklistedPrefixes: string[];
 
   constructor(source: SourceFile, options: IOptions) {

--- a/src/noInputRenameRule.ts
+++ b/src/noInputRenameRule.ts
@@ -26,7 +26,9 @@ export class Rule extends AbstractRule {
   `;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new InputMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
@@ -74,7 +76,7 @@ const whiteListAliases = new Set<string>([
   'aria-valuetext'
 ]);
 
-export class InputMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   private directiveSelectors!: ReadonlyArray<DirectiveMetadata['selector']>;
 
   protected visitNgDirective(metadata: DirectiveMetadata): void {

--- a/src/noLifecycleCallRule.ts
+++ b/src/noLifecycleCallRule.ts
@@ -18,11 +18,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'Avoid explicit calls to lifecycle methods';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new ExpressionCallMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class ExpressionCallMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   visitCallExpression(node: CallExpression): void {
     this.validateCallExpression(node);
     super.visitCallExpression(node);

--- a/src/noOutputNativeRule.ts
+++ b/src/noOutputNativeRule.ts
@@ -202,11 +202,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be named or renamed as a native event';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new NoOutputNativeWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class NoOutputNativeWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgOutput(property: PropertyDeclaration, output: Decorator, args: string[]): void {
     this.validateOutput(property, args);
     super.visitNgOutput(property, output, args);

--- a/src/noOutputOnPrefixRule.ts
+++ b/src/noOutputOnPrefixRule.ts
@@ -20,11 +20,13 @@ export class Rule extends Lint.Rules.AbstractRule {
   static readonly FAILURE_STRING = 'In the class "%s", the output property "%s" should not be prefixed with on';
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(new OutputWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class OutputWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgOutput(property: ts.PropertyDeclaration, output: ts.Decorator, args: string[]) {
     this.validateOutput(property);
     super.visitNgOutput(property, output, args);

--- a/src/noOutputRenameRule.ts
+++ b/src/noOutputRenameRule.ts
@@ -18,7 +18,9 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = '@Outputs should not be renamed';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new OutputMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
@@ -26,7 +28,7 @@ export const getFailureMessage = (): string => {
   return Rule.FAILURE_STRING;
 };
 
-export class OutputMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   private directiveSelectors!: ReadonlySet<DirectiveMetadata['selector']>;
 
   protected visitNgDirective(metadata: DirectiveMetadata): void {

--- a/src/noPipeImpureRule.ts
+++ b/src/noPipeImpureRule.ts
@@ -1,10 +1,10 @@
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure } from 'tslint';
 import { AbstractRule } from 'tslint/lib/rules';
-import { ClassDeclaration, Decorator, SourceFile, SyntaxKind } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
-import { getClassName, getDecoratorPropertyInitializer } from './util/utils';
+import { SourceFile, SyntaxKind } from 'typescript';
 import { PipeMetadata } from './angular';
+import { NgWalker } from './angular/ngWalker';
+import { getClassName } from './util/utils';
 
 interface FailureParameters {
   readonly className: string;
@@ -27,11 +27,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'Impure pipe declared in class %s';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-export class ClassMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgPipe(metadata: PipeMetadata): void {
     this.validatePipe(metadata);
     super.visitNgPipe(metadata);

--- a/src/pipePrefixRule.ts
+++ b/src/pipePrefixRule.ts
@@ -1,10 +1,10 @@
 import { sprintf } from 'sprintf-js';
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
+import { PipeMetadata } from './angular';
 import { NgWalker } from './angular/ngWalker';
 import { SelectorValidator } from './util/selectorValidator';
 import { getDecoratorArgument } from './util/utils';
-import { PipeMetadata } from './angular';
 
 export class Rule extends Lint.Rules.AbstractRule {
   static readonly metadata: Lint.IRuleMetadata = {
@@ -46,7 +46,9 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 
   apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    return this.applyWithWalker(new ClassMetadataWalker(sourceFile, this));
+    const walker = new Walker(sourceFile, this);
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -65,7 +67,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   }
 }
 
-export class ClassMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   constructor(sourceFile: ts.SourceFile, private rule: Rule) {
     super(sourceFile, rule.getOptions());
   }

--- a/src/preferInlineDecoratorRule.ts
+++ b/src/preferInlineDecoratorRule.ts
@@ -28,7 +28,9 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'Consider placing decorators on the same line as the property/method it decorates';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new PreferInlineDecoratorWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -36,7 +38,7 @@ export class Rule extends AbstractRule {
   }
 }
 
-export class PreferInlineDecoratorWalker extends NgWalker {
+class Walker extends NgWalker {
   private readonly blacklistedDecorators: ReadonlySet<string>;
 
   constructor(source: SourceFile, options: IOptions) {

--- a/src/preferOnPushComponentChangeDetectionRule.ts
+++ b/src/preferOnPushComponentChangeDetectionRule.ts
@@ -31,11 +31,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = `The changeDetection value of a component should be set to ChangeDetectionStrategy.${ON_PUSH}`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new PreferOnPushComponentChangeDetectionWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class PreferOnPushComponentChangeDetectionWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgComponent(metadata: ComponentMetadata): void {
     this.validateComponent(metadata);
     super.visitNgComponent(metadata);

--- a/src/preferOutputReadonlyRule.ts
+++ b/src/preferOutputReadonlyRule.ts
@@ -15,11 +15,13 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = 'Prefer to declare `@Output` as readonly since they are not supposed to be reassigned';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new OutputMetadataWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-export class OutputMetadataWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgOutput(property: PropertyDeclaration, output: Decorator, args: string[]) {
     this.validateOutput(property);
     super.visitNgOutput(property, output, args);

--- a/src/relativeUrlPrefixRule.ts
+++ b/src/relativeUrlPrefixRule.ts
@@ -18,11 +18,13 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = 'The ./ prefix is standard syntax for relative URLs. (https://angular.io/styleguide#style-05-04)';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new RelativeUrlPrefixWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class RelativeUrlPrefixWalker extends NgWalker {
+class Walker extends NgWalker {
   constructor(sourceFile: SourceFile, options: IOptions) {
     super(sourceFile, options);
   }

--- a/src/templateAccessibilityAltTextRule.ts
+++ b/src/templateAccessibilityAltTextRule.ts
@@ -1,8 +1,8 @@
-import { ElementAst, AttrAst, BoundElementPropertyAst, TextAst } from '@angular/compiler';
+import { AttrAst, BoundElementPropertyAst, ElementAst, TextAst } from '@angular/compiler';
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -20,11 +20,10 @@ export class Rule extends Rules.AbstractRule {
   static readonly DEFAULT_ELEMENTS = ['img', 'object', 'area', 'input[type="image"]'];
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityAltTextVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
@@ -32,7 +31,7 @@ export const getFailureMessage = (name: string): string => {
   return sprintf(Rule.FAILURE_STRING, name);
 };
 
-class TemplateAccessibilityAltTextVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(ast: ElementAst, context: any) {
     this.validateElement(ast);
     super.visitElement(ast, context);

--- a/src/templateAccessibilityElementsContentRule.ts
+++ b/src/templateAccessibilityElementsContentRule.ts
@@ -1,11 +1,11 @@
 import { ElementAst } from '@angular/compiler';
+import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript';
-import { sprintf } from 'sprintf-js';
-import { NgWalker } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 
-class TemplateAccessibilityElementsContentVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(ast: ElementAst, context: any) {
     this.validateElement(ast);
     super.visitElement(ast, context);
@@ -50,10 +50,9 @@ export class Rule extends Rules.AbstractRule {
   static readonly ELEMENTS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'button'];
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityElementsContentVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }

--- a/src/templateAccessibilityLabelForRule.ts
+++ b/src/templateAccessibilityLabelForRule.ts
@@ -1,8 +1,7 @@
-import { BoundDirectivePropertyAst, ElementAst } from '@angular/compiler';
-import { sprintf } from 'sprintf-js';
+import { ElementAst } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure, Rules, Utils } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 import { mayContainChildComponent } from './util/mayContainChildComponent';
 
@@ -55,15 +54,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly FORM_ELEMENTS = ['input', 'select', 'textarea'];
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityLabelForVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateAccessibilityLabelForVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(element: ElementAst, context: any) {
     this.validateElement(element);
     super.visitElement(element, context);

--- a/src/templateAccessibilityTabindexNoPositiveRule.ts
+++ b/src/templateAccessibilityTabindexNoPositiveRule.ts
@@ -1,7 +1,7 @@
 import { ElementAst } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 import { getAttributeValue } from './util/getAttributeValue';
 
@@ -19,15 +19,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_MESSAGE = 'tabindex attribute cannot be positive';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityTabindexNoPositiveVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateAccessibilityTabindexNoPositiveVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(ast: ElementAst, context: any): any {
     this.validateElement(ast);
     super.visitElement(ast, context);

--- a/src/templateAccessibilityTableScopeRule.ts
+++ b/src/templateAccessibilityTableScopeRule.ts
@@ -1,10 +1,10 @@
 import { ElementAst } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure, Rules, Utils } from 'tslint/lib';
 import { SourceFile } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 
-class TemplateAccessibilityTableScopeVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(ast: ElementAst, context: any) {
     this.validateElement(ast);
     super.visitElement(ast, context);
@@ -46,10 +46,9 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_MESSAGE = 'Scope attribute can only be on <th> element';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityTableScopeVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }

--- a/src/templateAccessibilityValidAriaRule.ts
+++ b/src/templateAccessibilityValidAriaRule.ts
@@ -1,9 +1,9 @@
 import { AttrAst, BoundElementPropertyAst } from '@angular/compiler';
+import { aria } from 'aria-query';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
-import { aria } from 'aria-query';
 import { getSuggestion } from './util/getSuggestion';
 
 const ariaAttributes: string[] = [...(<string[]>Array.from(aria.keys()))];
@@ -20,11 +20,10 @@ export class Rule extends Rules.AbstractRule {
   };
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateAccessibilityValidAriaVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
@@ -39,7 +38,7 @@ export const getFailureMessage = (name: string): string => {
   return message;
 };
 
-class TemplateAccessibilityValidAriaVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitAttr(ast: AttrAst, context: any) {
     this.validateAttribute(ast);
     super.visitAttr(ast, context);

--- a/src/templateBananaInBoxRule.ts
+++ b/src/templateBananaInBoxRule.ts
@@ -2,7 +2,7 @@ import { BoundEventAst } from '@angular/compiler';
 import { IRuleMetadata, Replacement, RuleFailure } from 'tslint';
 import { AbstractRule } from 'tslint/lib/rules';
 import { SourceFile } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 const INVALID_BOX = /^\[(?!\()(.*)(?<!\))\]$/;
@@ -24,15 +24,14 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'Invalid binding syntax. Use [(expr)] instead';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateBananaInBoxVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateBananaInBoxVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitEvent(ast: BoundEventAst, context: BasicTemplateAstVisitor): any {
     this.validateEvent(ast);
     super.visitEvent(ast, context);

--- a/src/templateClickEventsHaveKeyEventsRule.ts
+++ b/src/templateClickEventsHaveKeyEventsRule.ts
@@ -2,11 +2,11 @@ import { ElementAst } from '@angular/compiler';
 import { dom } from 'aria-query';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
+import { isHiddenFromScreenReader } from './util/isHiddenFromScreenReader';
 import { isInteractiveElement } from './util/isInteractiveElement';
 import { isPresentationRole } from './util/isPresentationRole';
-import { isHiddenFromScreenReader } from './util/isHiddenFromScreenReader';
 
 const domElements = new Set(dom.keys());
 
@@ -24,15 +24,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = 'click must be accompanied by either keyup, keydown or keypress event for accessibility';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateClickEventsHaveKeyEventsVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateClickEventsHaveKeyEventsVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(el: ElementAst, context: any) {
     this.validateElement(el);
     super.visitElement(el, context);

--- a/src/templateConditionalComplexityRule.ts
+++ b/src/templateConditionalComplexityRule.ts
@@ -2,7 +2,7 @@ import { AST, ASTWithSource, Binary, BoundDirectivePropertyAst, Lexer, Parser } 
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -29,11 +29,10 @@ export class Rule extends Rules.AbstractRule {
     "The condition complexity (cost '%s') exceeded the defined limit (cost '%s'). The conditional expression should be moved into the component.";
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateConditionalComplexityVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -85,7 +84,7 @@ const getTotalComplexity = (ast: AST): number => {
   return totalComplexity;
 };
 
-class TemplateConditionalComplexityVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: BasicTemplateAstVisitor): any {
     this.validateDirective(prop);
     super.visitDirectiveProperty(prop, context);

--- a/src/templateCyclomaticComplexityRule.ts
+++ b/src/templateCyclomaticComplexityRule.ts
@@ -2,7 +2,7 @@ import { BoundDirectivePropertyAst } from '@angular/compiler';
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -29,11 +29,10 @@ export class Rule extends Rules.AbstractRule {
   static readonly DEFAULT_MAX_COMPLEXITY = 5;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateConditionalComplexityVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 
   isEnabled(): boolean {
@@ -52,7 +51,7 @@ export const getFailureMessage = (maxComplexity = Rule.DEFAULT_MAX_COMPLEXITY): 
   return sprintf(Rule.FAILURE_STRING, maxComplexity);
 };
 
-class TemplateConditionalComplexityVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   totalComplexity = 0;
 
   visitDirectiveProperty(prop: BoundDirectivePropertyAst, context: any): any {

--- a/src/templateMouseEventsHaveKeyEventsRule.ts
+++ b/src/templateMouseEventsHaveKeyEventsRule.ts
@@ -1,7 +1,7 @@
 import { ElementAst } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -19,15 +19,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING_MOUSE_OUT = 'mouseout must be accompanied by blur event for accessibility';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateMouseEventsHaveKeyEventsVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateMouseEventsHaveKeyEventsVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(el: ElementAst, context: any) {
     this.validateElement(el);
     super.visitElement(el, context);

--- a/src/templateNoAnyRule.ts
+++ b/src/templateNoAnyRule.ts
@@ -3,7 +3,7 @@ import { IRuleMetadata, RuleFailure } from 'tslint';
 import { AbstractRule } from 'tslint/lib/rules';
 import { dedent } from 'tslint/lib/utils';
 import { SourceFile } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { RecursiveAngularExpressionVisitor } from './angular/templates/recursiveAngularExpressionVisitor';
 
 const ANY_TYPE_CAST_FUNCTION_NAME = '$any';
@@ -25,15 +25,14 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = `Avoid using '${ANY_TYPE_CAST_FUNCTION_NAME}' in templates`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        expressionVisitorCtrl: ExpressionVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { expressionVisitorCtrl: ExpressionVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class ExpressionVisitor extends RecursiveAngularExpressionVisitor {
+class ExpressionVisitorCtrl extends RecursiveAngularExpressionVisitor {
   visitMethodCall(ast: MethodCall, context: any): any {
     this.validateMethodCall(ast);
     super.visitMethodCall(ast, context);

--- a/src/templateNoAutofocusRule.ts
+++ b/src/templateNoAutofocusRule.ts
@@ -1,7 +1,7 @@
 import { AttrAst, BoundElementPropertyAst } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -18,15 +18,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = 'autofocus attribute should not be used, as it reduces usability and accessibility for users.';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateConditionalComplexityVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateConditionalComplexityVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitAttr(ast: AttrAst, context: any) {
     this.validateAttribute(ast);
     super.visitAttr(ast, context);

--- a/src/templateNoCallExpressionRule.ts
+++ b/src/templateNoCallExpressionRule.ts
@@ -2,7 +2,7 @@ import { MethodCall } from '@angular/compiler';
 import { IRuleMetadata, RuleFailure } from 'tslint';
 import { AbstractRule } from 'tslint/lib/rules';
 import { SourceFile } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 import { RecursiveAngularExpressionVisitor } from './angular/templates/recursiveAngularExpressionVisitor';
 
@@ -22,20 +22,21 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'Avoid calling expressions in templates';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        expressionVisitorCtrl: ExpressionVisitor,
-        templateVisitorCtrl: TemplateVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = {
+      expressionVisitorCtrl: ExpressionVisitorCtrl,
+      templateVisitorCtrl: TemplateVisitorCtrl
+    };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitEvent(): any {}
 }
 
-class ExpressionVisitor extends RecursiveAngularExpressionVisitor {
+class ExpressionVisitorCtrl extends RecursiveAngularExpressionVisitor {
   visitMethodCall(ast: MethodCall, context: any): any {
     this.validateMethodCall(ast);
     super.visitMethodCall(ast, context);

--- a/src/templateNoDistractingElementsRule.ts
+++ b/src/templateNoDistractingElementsRule.ts
@@ -2,7 +2,7 @@ import { ElementAst } from '@angular/compiler';
 import { sprintf } from 'sprintf-js';
 import { IRuleMetadata, RuleFailure, Rules } from 'tslint/lib';
 import { SourceFile } from 'typescript/lib/typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
 export class Rule extends Rules.AbstractRule {
@@ -19,11 +19,10 @@ export class Rule extends Rules.AbstractRule {
   static readonly FAILURE_STRING = 'Avoid using <%s/> elements as they create visual accessibility issues.';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        templateVisitorCtrl: TemplateNoDistractingElementsVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { templateVisitorCtrl: TemplateVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
@@ -31,7 +30,7 @@ export function getFailureMessage(element: string) {
   return sprintf(Rule.FAILURE_STRING, element);
 }
 
-class TemplateNoDistractingElementsVisitor extends BasicTemplateAstVisitor {
+class TemplateVisitorCtrl extends BasicTemplateAstVisitor {
   visitElement(prop: ElementAst, context: any): any {
     this.validateElement(prop);
     super.visitElement(prop, context);

--- a/src/templateNoNegatedAsyncRule.ts
+++ b/src/templateNoNegatedAsyncRule.ts
@@ -3,7 +3,7 @@ import { IRuleMetadata, RuleFailure } from 'tslint/lib';
 import { AbstractRule } from 'tslint/lib/rules';
 import { dedent } from 'tslint/lib/utils';
 import { SourceFile } from 'typescript';
-import { NgWalker } from './angular/ngWalker';
+import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { RecursiveAngularExpressionVisitor } from './angular/templates/recursiveAngularExpressionVisitor';
 
 const unstrictEqualityOperator = '==';
@@ -29,15 +29,14 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING_UNSTRICT_EQUALITY = 'Async pipes must use strict equality `===` when comparing with `false`';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(
-      new NgWalker(sourceFile, this.getOptions(), {
-        expressionVisitorCtrl: TemplateToNgTemplateVisitor
-      })
-    );
+    const walkerConfig: NgWalkerConfig = { expressionVisitorCtrl: ExpressionVisitorCtrl };
+    const walker = new NgWalker(sourceFile, this.getOptions(), walkerConfig);
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class TemplateToNgTemplateVisitor extends RecursiveAngularExpressionVisitor {
+class ExpressionVisitorCtrl extends RecursiveAngularExpressionVisitor {
   visitBinary(ast: Binary, context: any): any {
     this.validateBinary(ast);
     super.visitBinary(ast, context);

--- a/src/useComponentSelectorRule.ts
+++ b/src/useComponentSelectorRule.ts
@@ -26,11 +26,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = 'The selector of the component "%s" is mandatory';
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new UseComponentSelectorWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class UseComponentSelectorWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgComponent(metadata: ComponentMetadata): void {
     this.validateComponent(metadata);
     super.visitNgComponent(metadata);

--- a/src/useComponentViewEncapsulationRule.ts
+++ b/src/useComponentViewEncapsulationRule.ts
@@ -20,11 +20,13 @@ export class Rule extends AbstractRule {
   static readonly FAILURE_STRING = `Using ViewEncapsulation.${NONE} makes your styles global, which may have an unintended effect`;
 
   apply(sourceFile: SourceFile): RuleFailure[] {
-    return this.applyWithWalker(new ViewEncapsulationWalker(sourceFile, this.getOptions()));
+    const walker = new Walker(sourceFile, this.getOptions());
+
+    return this.applyWithWalker(walker);
   }
 }
 
-class ViewEncapsulationWalker extends NgWalker {
+class Walker extends NgWalker {
   protected visitNgComponent(metadata: ComponentMetadata): void {
     this.validateComponent(metadata);
     super.visitNgComponent(metadata);


### PR DESCRIPTION
In addition to removing the export from visitors/walkers that contained it, it renames them to a _generic_ name to avoid confusion (ex: for `templateNoAutofocus` rule we are naming its visitor as `TemplateConditionalComplexityVisitor`: https://github.com/mgechev/codelyzer/blob/799382fd1b16bbff9bfb1587b643c4125df8f393/src/templateNoAutofocusRule.ts#L29)... and to keep them consistent.