### PR TITLE
 fix(rule): 'contextual-decorator' - decorators with arguments, accessors and some missing decorators not being handled

### DIFF
--- a/test/contextualDecoratorRule.spec.ts
+++ b/test/contextualDecoratorRule.spec.ts
@@ -1,6 +1,6 @@
 import { getFailureMessage, Rule } from '../src/contextualDecoratorRule';
-import { AngularClassDecorators, AngularInnerClassDecorators } from '../src/util/utils';
-import { assertAnnotated, assertSuccess } from './testHelper';
+import { AngularClassDecorators } from '../src/util/utils';
+import { assertAnnotated, assertMultipleAnnotated, assertSuccess } from './testHelper';
 
 const {
   metadata: { ruleName }
@@ -9,472 +9,1033 @@ const {
 describe(ruleName, () => {
   describe('failure', () => {
     describe('Injectable', () => {
-      it('should fail if a property is decorated with @ContentChild() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @ContentChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChild
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @ContentChildren() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChildren
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @HostBinding() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @HostBinding('class.card-outline') private isCardOutline: boolean;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostBinding
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a method is decorated with @HostListener() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @HostListener('mouseover')
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~
-            mouseOver() {
-              console.log('mouseOver');
+      describe('accessors', () => {
+        it('should fail if getter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostListener
-          }),
-          ruleName,
-          source
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              set label(value: string) {
+                this._label = value;
+              }
+              get label(): string {
+                return this._label;
+              }
+              private _label: string;
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ViewChild(Pane)
+              ~~~~~~~~~~~~~~~~
+              set label(value: Pane) {
+                doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Input() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @Input() label: string;
-            ~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Input
-          }),
-          ruleName,
-          source
+      describe('methods', () => {
+        it('should fail if a method is decorated with @HostListener() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @HostListener('mouseover')
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+              mouseOver() {
+                this.doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Output() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @Output() emitter = new EventEmitter<void>();
-            ~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Output
-          }),
-          ruleName,
-          source
+      describe('parameter properties', () => {
+        it('should fail if a parameter property is decorated with @Attribute() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @Attribute('test') private readonly test: string
+                ~~~~~~~~~~~~~~~~~~
+              ) {}
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChild() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @ViewChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChild
-          }),
-          ruleName,
-          source
+      describe('properties', () => {
+        it('should fail if a property is decorated with @ContentChild() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ContentChildren() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @HostBinding() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @HostBinding('class.card-outline') private isCardOutline: boolean;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Input() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @Input() label: string;
+              ~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Output() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @Output() emitter = new EventEmitter<void>();
+              ~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ViewChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChildren() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ViewChildren(Pane) panes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Injectable
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChildren() decorator', () => {
-        const source = `
-          @Injectable()
-          class Test {
-            @ViewChildren(Pane) panes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Injectable,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChildren
-          }),
-          ruleName,
-          source
+      describe('multiple declarations', () => {
+        it('should fail if declarations are decorated with non allowed decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+
+              @Input()
+              ^^^^^^^^
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
+
+              @ViewChild(Pane)
+              ################
+              set label(value: Pane) {
+                doSomething();
+              }
+
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Attribute('test') private readonly test: string,
+                %%%%%%%%%%%%%%%%%%
+                @Inject(LOCALE_ID) localeId: string
+              ) {}
+
+              @HostListener('mouseover')
+              ¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶
+              mouseOver() {
+                this.doSomething();
+              }
+
+              clickHandler(): void {}
+            }
+          `;
+          const msg = getFailureMessage({
+            classDecoratorName: AngularClassDecorators.Injectable
+          });
+          const failures = [
+            {
+              char: '~',
+              msg
+            },
+            {
+              char: '^',
+              msg
+            },
+            {
+              char: '#',
+              msg
+            },
+            {
+              char: '%',
+              msg
+            },
+            {
+              char: '¶',
+              msg
+            }
+          ];
+          assertMultipleAnnotated({
+            failures,
+            ruleName,
+            source
+          });
         });
       });
     });
 
     describe('NgModule', () => {
-      it('should fail if a property is decorated with @ContentChild() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @ContentChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChild
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @ContentChildren() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChildren
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @HostBinding() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @HostBinding('class.card-outline') private isCardOutline: boolean;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostBinding
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a method is decorated with @HostListener() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @HostListener('mouseover')
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~
-            mouseOver() {
-              console.log('mouseOver');
+      describe('accessors', () => {
+        it('should fail if getter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostListener
-          }),
-          ruleName,
-          source
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              set label(value: string) {
+                this._label = value;
+              }
+              get label(): string {
+                return this._label;
+              }
+              private _label: string;
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ViewChild(Pane)
+              ~~~~~~~~~~~~~~~~
+              set label(value: Pane) {
+                doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Input() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @Input() label: string;
-            ~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Input
-          }),
-          ruleName,
-          source
+      describe('methods', () => {
+        it('should fail if a method is decorated with @HostListener() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @HostListener('mouseover')
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+              mouseOver() {
+                this.doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Output() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @Output() emitter = new EventEmitter<void>();
-            ~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Output
-          }),
-          ruleName,
-          source
+      describe('parameter properties', () => {
+        it('should fail if a parameter property is decorated with @Attribute() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @Attribute('test') private readonly test: string
+                ~~~~~~~~~~~~~~~~~~
+              ) {}
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChild() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @ViewChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChild
-          }),
-          ruleName,
-          source
+      describe('properties', () => {
+        it('should fail if a property is decorated with @ContentChild() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ContentChildren() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @HostBinding() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @HostBinding('class.card-outline') private isCardOutline: boolean;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Input() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @Input() label: string;
+              ~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Output() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @Output() emitter = new EventEmitter<void>();
+              ~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ViewChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChildren() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ViewChildren(Pane) panes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.NgModule
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChildren() decorator', () => {
-        const source = `
-          @NgModule()
-          class Test {
-            @ViewChildren(Pane) panes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.NgModule,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChildren
-          }),
-          ruleName,
-          source
+      describe('multiple declarations', () => {
+        it('should fail if declarations are decorated with non allowed decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+
+              @Input()
+              ^^^^^^^^
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
+
+              @ViewChild(Pane)
+              ################
+              set label(value: Pane) {
+                doSomething();
+              }
+
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Attribute('test') private readonly test: string,
+                %%%%%%%%%%%%%%%%%%
+                @Inject(LOCALE_ID) localeId: string
+              ) {}
+
+              @HostListener('mouseover')
+              ¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶
+              mouseOver() {
+                this.doSomething();
+              }
+
+              clickHandler(): void {}
+            }
+          `;
+          const msg = getFailureMessage({
+            classDecoratorName: AngularClassDecorators.NgModule
+          });
+          const failures = [
+            {
+              char: '~',
+              msg
+            },
+            {
+              char: '^',
+              msg
+            },
+            {
+              char: '#',
+              msg
+            },
+            {
+              char: '%',
+              msg
+            },
+            {
+              char: '¶',
+              msg
+            }
+          ];
+          assertMultipleAnnotated({
+            failures,
+            ruleName,
+            source
+          });
         });
       });
     });
 
     describe('Pipe', () => {
-      it('should fail if a property is decorated with @ContentChild() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @ContentChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChild
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @ContentChildren() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ContentChildren
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a property is decorated with @HostBinding() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @HostBinding('class.card-outline') private isCardOutline: boolean;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostBinding
-          }),
-          ruleName,
-          source
-        });
-      });
-
-      it('should fail if a method is decorated with @HostListener() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @HostListener('mouseover')
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~
-            mouseOver() {
-              console.log('mouseOver');
+      describe('accessors', () => {
+        it('should fail if getter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.HostListener
-          }),
-          ruleName,
-          source
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @Input()
+              ~~~~~~~~
+              set label(value: string) {
+                this._label = value;
+              }
+              get label(): string {
+                return this._label;
+              }
+              private _label: string;
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if setter accessor is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ViewChild(Pane)
+              ~~~~~~~~~~~~~~~~
+              set label(value: Pane) {
+                doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Input() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @Input() label: string;
-            ~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Input
-          }),
-          ruleName,
-          source
+      describe('methods', () => {
+        it('should fail if a method is decorated with @HostListener() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @HostListener('mouseover')
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+              mouseOver() {
+                this.doSomething();
+              }
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @Output() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @Output() emitter = new EventEmitter<void>();
-            ~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.Output
-          }),
-          ruleName,
-          source
+      describe('parameter properties', () => {
+        it('should fail if a parameter property is decorated with @Attribute() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @Attribute('test') private readonly test: string
+                ~~~~~~~~~~~~~~~~~~
+              ) {}
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChild() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @ViewChild(Pane) pane: Pane;
-            ~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChild
-          }),
-          ruleName,
-          source
+      describe('properties', () => {
+        it('should fail if a property is decorated with @ContentChild() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ContentChildren() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @HostBinding() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @HostBinding('class.card-outline') private isCardOutline: boolean;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Input() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @Input() label: string;
+              ~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @Output() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @Output() emitter = new EventEmitter<void>();
+              ~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ViewChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
+        });
+
+        it('should fail if a property is decorated with @ViewChildren() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ViewChildren(Pane) panes: QueryList<Pane>;
+              ~~~~~~~~~~~~~~~~~~~
+            }
+          `;
+          assertAnnotated({
+            message: getFailureMessage({
+              classDecoratorName: AngularClassDecorators.Pipe
+            }),
+            ruleName,
+            source
+          });
         });
       });
 
-      it('should fail if a property is decorated with @ViewChildren() decorator', () => {
-        const source = `
-          @Pipe()
-          class Test {
-            @ViewChildren(Pane) panes: QueryList<Pane>;
-            ~~~~~~~~~~~~~~~~~~~
-          }
-        `;
-        assertAnnotated({
-          message: getFailureMessage({
-            classDecoratorName: AngularClassDecorators.Pipe,
-            className: 'Test',
-            innerClassDecoratorName: AngularInnerClassDecorators.ViewChildren
-          }),
-          ruleName,
-          source
+      describe('multiple declarations', () => {
+        it('should fail if declarations are decorated with non allowed decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+              ~~~~~~~~~~~~~~~~~~~
+
+              @Input()
+              ^^^^^^^^
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
+
+              @ViewChild(Pane)
+              ################
+              set label(value: Pane) {
+                doSomething();
+              }
+
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Attribute('test') private readonly test: string,
+                %%%%%%%%%%%%%%%%%%
+                @Inject(LOCALE_ID) localeId: string
+              ) {}
+
+              @HostListener('mouseover')
+              ¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶
+              mouseOver() {
+                this.doSomething();
+              }
+
+              clickHandler(): void {}
+            }
+          `;
+          const msg = getFailureMessage({
+            classDecoratorName: AngularClassDecorators.Pipe
+          });
+          const failures = [
+            {
+              char: '~',
+              msg
+            },
+            {
+              char: '^',
+              msg
+            },
+            {
+              char: '#',
+              msg
+            },
+            {
+              char: '%',
+              msg
+            },
+            {
+              char: '¶',
+              msg
+            }
+          ];
+          assertMultipleAnnotated({
+            failures,
+            ruleName,
+            source
+          });
         });
       });
     });
@@ -482,21 +1043,23 @@ describe(ruleName, () => {
     describe('multiple decorators per file', () => {
       it('should fail if contains @Directive and @Pipe decorators and the @Pipe contains a not allowed decorator', () => {
         const source = `
-          @Directive()
+          @Directive({
+            selector: 'test'
+          })
           class TestDirective {
             @Input() label: string;
           }
 
-          @Pipe()
+          @Pipe({
+            name: 'test'
+          })
           class Test {
             @Input() label: string;
             ~~~~~~~~
           }
         `;
         const message = getFailureMessage({
-          classDecoratorName: AngularClassDecorators.Pipe,
-          className: 'Test',
-          innerClassDecoratorName: AngularInnerClassDecorators.Input
+          classDecoratorName: AngularClassDecorators.Pipe
         });
         assertAnnotated({
           message,
@@ -509,178 +1072,898 @@ describe(ruleName, () => {
 
   describe('success', () => {
     describe('Component', () => {
-      it('should succeed if a property is decorated with @ContentChild() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @ContentChild(Pane) pane: Pane;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @ContentChildren() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @HostBinding() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @HostBinding('class.card-outline') private isCardOutline: boolean;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a method is decorated with @HostListener() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @HostListener('mouseover')
-            mouseOver() {
-              console.log('mouseOver');
+      describe('accessors', () => {
+        it('should succeed if getter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @Input()
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
+          `;
+          assertSuccess(ruleName, source);
+        });
 
-      it('should succeed if a property is decorated with @Input() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @Input() label: string;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @Output() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @Output() emitter = new EventEmitter<void>();
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @ViewChild() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @ViewChild(Pane)
-            set pane(value: Pane) {
-              console.log('panel setter called');
+        it('should succeed if setter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @Input()
+              set label(value: string) {
+                this._label = value;
+              }
+              get label(): string {
+                return this._label;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertSuccess(ruleName, source);
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if setter accessor is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ViewChild(Pane)
+              set label(value: Pane) {
+                doSomething();
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
       });
 
-      it('should succeed if a property is decorated with @ViewChildren() decorator', () => {
-        const source = `
-          @Component()
-          class Test {
-            @ViewChildren(Pane) panes: QueryList<Pane>;
-          }
-        `;
-        assertSuccess(ruleName, source);
+      describe('methods', () => {
+        it('should succeed if a method is decorated with @HostListener() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @HostListener('mouseover')
+              mouseOver() {
+                this.doSomething();
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('parameter properties', () => {
+        it('should succeed if a parameter property is decorated with @Host() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              constructor(
+                @Host() private readonly host: DynamicHost
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Inject() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              constructor(
+                @Inject(LOCALE_ID) private readonly localeId: string
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Optional() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              constructor(
+                @Optional() testBase: TestBase,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Self() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              constructor(
+                @Self() public readonly test: Test,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @SkipSelf() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              constructor(
+                @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('properties', () => {
+        it('should succeed if a property is decorated with @ContentChild() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ContentChildren() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @HostBinding() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @HostBinding('class.card-outline') private isCardOutline: boolean;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @Input() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @Input() label: string;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @Output() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @Output() emitter = new EventEmitter<void>();
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ViewChild(Pane)
+              set pane(value: Pane) {
+                console.log('panel setter called');
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ViewChildren() decorator', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ViewChildren(Pane) panes: QueryList<Pane>;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('multiple declarations', () => {
+        it('should succeed if declarations are decorated with allowed decorators', () => {
+          const source = `
+            @Component({
+              template: 'Hi!'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+
+              @Input()
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
+
+              @ViewChild(Pane)
+              set label(value: Pane) {
+                doSomething();
+              }
+
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Attribute('test') private readonly test: string,
+                @Host() @Optional() private readonly host: DynamicHost,
+                @Inject(LOCALE_ID) private readonly localeId: string,
+                @Inject(TEST_BASE) @Optional() testBase: TestBase,
+                @Optional() @Self() public readonly test: Test,
+                @Optional() @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+
+              @HostListener('mouseover')
+              mouseOver(): void {
+                this.doSomething();
+              }
+
+              clickHandler(): void {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
       });
     });
 
     describe('Directive', () => {
-      it('should succeed if a property is decorated with @ContentChild() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @ContentChild(Pane) pane: Pane;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @ContentChildren() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @HostBinding() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @HostBinding('class.card-outline') private isCardOutline: boolean;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a method is decorated with @HostListener() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @HostListener('mouseover')
-            mouseOver() {
-              console.log('mouseOver');
+      describe('accessors', () => {
+        it('should succeed if getter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @Input()
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
+          `;
+          assertSuccess(ruleName, source);
+        });
 
-      it('should succeed if a property is decorated with @Input() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @Input() label: string;
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @Output() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @Output() emitter = new EventEmitter<void>();
-          }
-        `;
-        assertSuccess(ruleName, source);
-      });
-
-      it('should succeed if a property is decorated with @ViewChild() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @ViewChild(Pane)
-            set pane(value: Pane) {
-              console.log('panel setter called');
+        it('should succeed if setter accessor is decorated with @Input() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @Input()
+              set label(value: string) {
+                this._label = value;
+              }
+              get label(): string {
+                return this._label;
+              }
+              private _label: string;
             }
-          }
-        `;
-        assertSuccess(ruleName, source);
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if setter accessor is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ViewChild(Pane)
+              set label(value: Pane) {
+                doSomething();
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
       });
 
-      it('should succeed if a property is decorated with @ViewChildren() decorator', () => {
-        const source = `
-          @Directive()
-          class Test {
-            @ViewChildren(Pane) panes: QueryList<Pane>;
-          }
-        `;
-        assertSuccess(ruleName, source);
+      describe('methods', () => {
+        it('should succeed if a method is decorated with @HostListener() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @HostListener('mouseover')
+              mouseOver() {
+                this.doSomething();
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('parameter properties', () => {
+        it('should succeed if a parameter property is decorated with @Host() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              constructor(
+                @Host() private readonly host: DynamicHost
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Inject() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              constructor(
+                @Inject(LOCALE_ID) private readonly localeId: string
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Optional() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              constructor(
+                @Optional() testBase: TestBase,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Self() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              constructor(
+                @Self() public readonly test: Test,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @SkipSelf() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              constructor(
+                @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('properties', () => {
+        it('should succeed if a property is decorated with @ContentChild() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ContentChildren() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ContentChildren(Pane, { descendants: true }) arbitraryNestedPanes: QueryList<Pane>;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @HostBinding() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @HostBinding('class.card-outline') private isCardOutline: boolean;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @Input() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @Input() label: string;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @Output() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @Output() emitter = new EventEmitter<void>();
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ViewChild() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ViewChild(Pane)
+              set pane(value: Pane) {
+                console.log('panel setter called');
+              }
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a property is decorated with @ViewChildren() decorator', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ViewChildren(Pane) panes: QueryList<Pane>;
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('multiple declarations', () => {
+        it('should succeed if declarations are decorated with allowed decorators', () => {
+          const source = `
+            @Directive({
+              selector: 'test'
+            })
+            class Test {
+              @ContentChild(Pane) pane: Pane;
+
+              @Input()
+              get label(): string {
+                return this._label;
+              }
+              set label(value: string) {
+                this._label = value;
+              }
+              private _label: string;
+
+              @ViewChild(Pane)
+              set label(value: Pane) {
+                doSomething();
+              }
+
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Attribute('test') private readonly test: string,
+                @Host() @Optional() private readonly host: DynamicHost,
+                @Inject(LOCALE_ID) private readonly localeId: string,
+                @Inject(TEST_BASE) @Optional() testBase: TestBase,
+                @Optional() @Self() public readonly test: Test,
+                @Optional() @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+
+              @HostListener('mouseover')
+              mouseOver(): void {
+                this.doSomething();
+              }
+
+              clickHandler(): void {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+    });
+
+    describe('Injectable', () => {
+      describe('parameter properties', () => {
+        it('should succeed if a parameter property is decorated with @Host() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @Host() private readonly host: DynamicHost
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Inject() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @Inject(LOCALE_ID) private readonly localeId: string
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Optional() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @Optional() testBase: TestBase,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Self() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @Self() public readonly test: Test,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @SkipSelf() decorator', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              constructor(
+                @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('multiple declarations', () => {
+        it('should succeed if declarations are decorated with allowed decorators', () => {
+          const source = `
+            @Injectable({
+              providedIn: 'root'
+            })
+            class Test {
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Host() @Optional() private readonly host: DynamicHost,
+                @Inject(LOCALE_ID) private readonly localeId: string,
+                @Inject(TEST_BASE) @Optional() testBase: TestBase,
+                @Optional() @Self() public readonly test: Test,
+                @Optional() @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+
+              clickHandler(): void {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+    });
+
+    describe('NgModule', () => {
+      describe('parameter properties', () => {
+        it('should succeed if a parameter property is decorated with @Host() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @Host() private readonly host: DynamicHost
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Inject() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @Inject(LOCALE_ID) private readonly localeId: string
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Optional() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @Optional() testBase: TestBase,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Self() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @Self() public readonly test: Test,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @SkipSelf() decorator', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              constructor(
+                @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('multiple declarations', () => {
+        it('should succeed if declarations are decorated with allowed decorators', () => {
+          const source = `
+            @NgModule({
+              providers: []
+            })
+            class Test {
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Host() @Optional() private readonly host: DynamicHost,
+                @Inject(LOCALE_ID) private readonly localeId: string,
+                @Inject(TEST_BASE) @Optional() testBase: TestBase,
+                @Optional() @Self() public readonly test: Test,
+                @Optional() @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+
+              clickHandler(): void {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+    });
+
+    describe('Pipe', () => {
+      describe('parameter properties', () => {
+        it('should succeed if a parameter property is decorated with @Host() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @Host() private readonly host: DynamicHost
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Inject() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @Inject(LOCALE_ID) private readonly localeId: string
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Optional() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @Optional() testBase: TestBase,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @Self() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @Self() public readonly test: Test,
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+
+        it('should succeed if a parameter property is decorated with @SkipSelf() decorator', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              constructor(
+                @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
+      });
+
+      describe('multiple declarations', () => {
+        it('should succeed if declarations are decorated with allowed decorators', () => {
+          const source = `
+            @Pipe({
+              name: 'test'
+            })
+            class Test {
+              get type(): string {
+                return this._type;
+              }
+              set type(value: string) {
+                this._type = value;
+              }
+              private _type: string;
+
+              private prop: string | undefined;
+
+              constructor(
+                @Host() @Optional() private readonly host: DynamicHost,
+                @Inject(LOCALE_ID) private readonly localeId: string,
+                @Inject(TEST_BASE) @Optional() testBase: TestBase,
+                @Optional() @Self() public readonly test: Test,
+                @Optional() @SkipSelf() protected readonly parentTest: ParentTest
+              ) {}
+
+              clickHandler(): void {}
+            }
+          `;
+          assertSuccess(ruleName, source);
+        });
       });
     });
 


### PR DESCRIPTION
This:

 - Fixes a bug introduced in the new version; (Currently it's not reporting failures if the decorator has arguments due to https://github.com/mgechev/codelyzer/blob/c07ac5e085365562301672cef4e59f159b7a84d0/src/contextualDecoratorRule.ts#L66
 - Reports failures for `accessors` with decorators (ex. `@Input`, `@ViewChild`);
 - Reports failures for `parameter properties` decorators (ex. `@Attribute`, `@Host`, etc...);

Fixes #776.