### PR TITLE
fix(rule): detect trackBy function when ngFor spans  multiple lines

### DIFF
--- a/src/templateUseTrackByFunctionRule.ts
+++ b/src/templateUseTrackByFunctionRule.ts
@@ -5,7 +5,7 @@ import { SourceFile } from 'typescript/lib/typescript';
 import { NgWalker, NgWalkerConfig } from './angular/ngWalker';
 import { BasicTemplateAstVisitor } from './angular/templates/basicTemplateAstVisitor';
 
-const PATTERN = /\s*ngFor.*\s*trackBy\s*:|\[ngForTrackBy\]\s*=\s*['"].*['"]/;
+const PATTERN = /trackBy\s*:|\[ngForTrackBy\]\s*=\s*['"].*['"]/;
 // current offset into the template
 let currentOffset = 0;
 

--- a/test/templateUseTrackByFunctionRule.spec.ts
+++ b/test/templateUseTrackByFunctionRule.spec.ts
@@ -213,5 +213,23 @@ describe(ruleName, () => {
       `;
       assertSuccess(ruleName, source);
     });
+
+    it('should succeed when trackBy function is on a different line', () => {
+      const source = `
+        @Component({
+          template: \`
+            <div *ngFor="
+              let item of [1, 2, 3];
+              let i = index;
+              trackBy : trackByFn
+            ">
+              {{ item }}
+            </div>
+          \`
+        })
+        class Bar {}
+      `;
+      assertSuccess(ruleName, source);
+    });
   });
 });


### PR DESCRIPTION
Prettier formats some *ngFor expressions across multiple lines which currently isn't picked up by codelyzer, I'm not sure if there is a tighter way of fixing this rather than just deleting the start of the regexp, but all the tests pass so maybe this is enough 😄 