### PR TITLE
fix(angular): update function call broken by Angular changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@angular/compiler": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.1.3.tgz",
-      "integrity": "sha512-mKeRkpPy/iBPGBCVQIPF9x4f1S68ilEYaQTTfHoLR0OfivEQsyGuf2GEegwbTosEBX3JF+0JHfCNvsAE1zI5Og==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.0.tgz",
+      "integrity": "sha512-5OlLfL6cie8XAY+pPc+iCouzO07V5Lahmyr6OVKMjePJO5SkPuVdm/OPdR43n3VNlOje4bwHHvoTok1BKepDTg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@angular/core": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.1.3.tgz",
-      "integrity": "sha512-45ocymDkXhmgluhaIX/O6IgqGPCLOlSYEXYpJ660QS1JgprKU7Ae9mWiNSmbBmT0OGV/sKKF8SNMQAGOHgio6Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.0.tgz",
+      "integrity": "sha512-Sg7zPaaAeV73zobKmxvdQ0pDhZAigDKM9jOqm2q19ucdOLBBQJnZf7JkZYO+KWm56Ttz76Jetl+neR5zzGg/bg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   },
   "homepage": "https://github.com/mgechev/codelyzer#readme",
   "devDependencies": {
-    "@angular/compiler": "8.1.3",
-    "@angular/core": "8.1.3",
+    "@angular/compiler": "8.2.0",
+    "@angular/core": "8.2.0",
     "@commitlint/cli": "8.1.0",
     "@commitlint/config-angular": "8.1.0",
     "@types/chai": "4.2.2",

--- a/src/templateConditionalComplexityRule.ts
+++ b/src/templateConditionalComplexityRule.ts
@@ -9,7 +9,14 @@ export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
     description: "The condition complexity shouldn't exceed a rational limit in a template.",
     optionExamples: [true, [true, 4]],
-    options: { items: { type: 'string' }, maxLength: 1, minLength: 0, type: 'array' },
+    options: {
+      items: {
+        type: 'string'
+      },
+      maxLength: 1,
+      minLength: 0,
+      type: 'array'
+    },
     optionsDescription: 'Determine the maximum number of Boolean operators allowed.',
     rationale: 'An important complexity complicates the tests and the maintenance.',
     ruleName: 'template-conditional-complexity',

--- a/src/templateConditionalComplexityRule.ts
+++ b/src/templateConditionalComplexityRule.ts
@@ -9,14 +9,7 @@ export class Rule extends Rules.AbstractRule {
   static readonly metadata: IRuleMetadata = {
     description: "The condition complexity shouldn't exceed a rational limit in a template.",
     optionExamples: [true, [true, 4]],
-    options: {
-      items: {
-        type: 'string'
-      },
-      maxLength: 1,
-      minLength: 0,
-      type: 'array'
-    },
+    options: { items: { type: 'string' }, maxLength: 1, minLength: 0, type: 'array' },
     optionsDescription: 'Determine the maximum number of Boolean operators allowed.',
     rationale: 'An important complexity complicates the tests and the maintenance.',
     ruleName: 'template-conditional-complexity',
@@ -54,7 +47,7 @@ export const getFailureMessage = (totalComplexity: number, maxComplexity = Rule.
 const getTotalComplexity = (ast: AST): number => {
   const expr = ((ast as ASTWithSource).source || '').replace(/\s/g, '');
   const expressionParser = new Parser(new Lexer());
-  const astWithSource = expressionParser.parseAction(expr, null);
+  const astWithSource = expressionParser.parseAction(expr, null, 0);
   const conditions: Binary[] = [];
   let totalComplexity = 0;
   let condition = astWithSource.ast as Binary;


### PR DESCRIPTION
angular/angular#31391 introduces a breaking change to `parseAction`,
which now requires at least three parameters. This provides a
fix-forward for when the change lands.