### PR TITLE
Add missing recommended rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Below you can find a recommended configuration which is based on the [Angular St
   "template-banana-in-box": true,
   "template-no-negated-async": true,
   "use-lifecycle-interface": true,
-  "use-pipe-transform-interface": true
+  "use-pipe-transform-interface": true,
 
   // The rules component-class-suffix and directive-class-suffix have the following arguments:
   // [ENABLED, "suffix" | ["listOfSuffixes"]]

--- a/README.md
+++ b/README.md
@@ -261,15 +261,21 @@ Below you can find a recommended configuration which is based on the [Angular St
   "directive-selector": [true, "attribute", ["dir-prefix1", "dir-prefix2"], "camelCase"],
 
   "component-max-inline-declarations": true,
+  "contextual-lifecycle": true,
+  "no-conflicting-lifecycle": true,
   "no-host-metadata-property": true,
   "no-input-rename": true,
   "no-inputs-metadata-property": true,
+  "no-output-native": true,
   "no-output-on-prefix": true,
   "no-output-rename": true,
   "no-outputs-metadata-property": true,
   "no-queries-metadata-property": true,
   "prefer-inline-decorator": true,
+  "template-banana-in-box": true,
+  "template-no-negated-async": true,
   "use-lifecycle-interface": true,
+  "use-pipe-transform-interface": true
 
   // The rules component-class-suffix and directive-class-suffix have the following arguments:
   // [ENABLED, "suffix" | ["listOfSuffixes"]]


### PR DESCRIPTION
These rules are defined in the latest Angular template ([here](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/workspace/files/tslint.json.template)) and were missing from the recommended rules list.



