### PR TITLE
fix: add support for tslint 6.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "peerDependencies": {
     "@angular/compiler": ">=2.3.1 <10.0.0 || >9.0.0-beta <10.0.0 || >9.1.0-beta <10.0.0 || >9.2.0-beta <10.0.0",
     "@angular/core": ">=2.3.1 <10.0.0 || >9.0.0-beta <10.0.0 || >9.1.0-beta <10.0.0 || >9.2.0-beta <10.0.0",
-    "tslint": "^5.0.0"
+    "tslint": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "app-root-path": "^2.2.1",


### PR DESCRIPTION
Tslint 6.0+ adds support for TypeScript 3.8 syntax. 

https://github.com/palantir/tslint/pull/4915